### PR TITLE
feat: enable supabase-backed storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env.local (ignored by git) and fill in your Supabase project
+# details. Leaving the variables empty keeps the app using browser localStorage.
+
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=

--- a/README.md
+++ b/README.md
@@ -32,7 +32,18 @@ npm run preview
 ```
 
 ## Data
-All data is stored in the browser `localStorage` under key `cpdb.v1`.
+By default data is stored in the browser `localStorage` under key `cpdb.v1`.
+
+To use a shared Supabase database instead:
+
+1. Create a Supabase project and run [`supabase/schema.sql`](supabase/schema.sql)
+   to create tables and policies.
+2. Copy `.env.example` to `.env.local` (or set the variables another way) and
+   provide values for `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.
+
+Once configured the UI will display **Storage: Supabase** and all reads/writes
+go through Supabase. See [supabase/README.md](supabase/README.md) for more
+details.
 
 
 ## GitHub Setup

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,6 +14,7 @@ import {
   createPO as createPORecord,
   deletePO as deletePORecord,
   updateProject as updateProjectRecord,
+  storageProvider,
 } from '../lib/storage'
 import Button from '../components/ui/Button'
 import Input from '../components/ui/Input'
@@ -29,6 +30,15 @@ export default function App() {
   const [isLoading, setIsLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [isSyncing, setIsSyncing] = useState(false)
+
+  const usingSupabase = storageProvider === 'supabase'
+  const storageLabel = usingSupabase ? 'Supabase' : 'Browser'
+  const storageTitle = usingSupabase
+    ? 'Data is stored in Supabase and shared across sessions.'
+    : 'Data is stored in this browser only.'
+  const storageBadgeClass = usingSupabase
+    ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+    : 'border-amber-200 bg-amber-50 text-amber-700'
 
   // Search
   const [customerQuery, setCustomerQuery] = useState('')
@@ -765,6 +775,12 @@ export default function App() {
         <div className='mb-6 flex items-center justify-between'>
           <h1 className='text-2xl font-semibold tracking-tight'>CustomerProjectDB</h1>
           <div className='flex items-center gap-3'>
+            <span
+              className={`rounded-full border px-3 py-1 text-xs font-medium ${storageBadgeClass}`}
+              title={storageTitle}
+            >
+              Storage: {storageLabel}
+            </span>
             {isSyncing && (
               <span className='flex items-center gap-2 text-xs font-medium text-slate-500'>
                 <span className='h-2.5 w-2.5 animate-spin rounded-full border-2 border-slate-300 border-t-sky-500' aria-hidden />
@@ -782,6 +798,13 @@ export default function App() {
             </Button>
           </div>
         </div>
+
+        {!usingSupabase && (
+          <div className='mb-6 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800'>
+            Supabase is not configured — data stays in this browser only. Set VITE_SUPABASE_URL and
+            VITE_SUPABASE_ANON_KEY to sync with Supabase.
+          </div>
+        )}
 
         <Card className='mb-6 panel'>
           <CardHeader>

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -34,9 +34,12 @@ type StorageApi = {
   deletePO(poId: string): Promise<void>
 }
 
-const storage: StorageApi = isSupabaseConfigured()
-  ? createSupabaseStorage(getSupabaseClient())
-  : createBrowserStorage()
+export const storageProvider: 'supabase' | 'browser' = isSupabaseConfigured() ? 'supabase' : 'browser'
+
+const storage: StorageApi =
+  storageProvider === 'supabase'
+    ? createSupabaseStorage(getSupabaseClient())
+    : createBrowserStorage()
 
 export const listCustomers = storage.listCustomers
 export const listProjectsByCustomer = storage.listProjectsByCustomer

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,27 @@
+# Supabase setup
+
+The app can use Supabase as its backing store instead of browser `localStorage`.
+Follow these steps to prepare a project:
+
+1. Create a new project in [Supabase](https://supabase.com/) and wait for the
+   database to provision.
+2. Open the SQL Editor and run [`schema.sql`](./schema.sql). The script creates
+   the tables (`customers`, `projects`, `work_orders`, `purchase_orders`),
+   foreign keys, indexes, and permissive Row Level Security policies that allow
+   the anonymous key to read/write data.
+3. In the Supabase dashboard copy the Project URL and the `anon` public API key.
+4. Copy `.env.example` to `.env.local` in the project root (or otherwise
+   provide the variables) with:
+
+   ```bash
+   VITE_SUPABASE_URL="https://YOUR-PROJECT.supabase.co"
+   VITE_SUPABASE_ANON_KEY="YOUR_ANON_KEY"
+   ```
+
+5. Restart `npm run dev` (or rebuild for production). When the variables are
+   present the UI will show "Storage: Supabase" and data will be saved to the
+   remote database.
+
+The script is idempotent so you can re-run it to refresh the policies. To remove
+all data simply truncate the tables in Supabase or use the dashboard to delete
+rows.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,155 @@
+-- Supabase schema and policies for CustomerProjectDB
+-- Run this in the Supabase SQL editor (or via the CLI) to prepare the database
+-- for the front-end app. The script is idempotent so it can be applied multiple
+-- times.
+
+create extension if not exists "pgcrypto";
+
+create table if not exists public.customers (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  address text,
+  contact_name text,
+  contact_phone text,
+  contact_email text,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.projects (
+  id uuid primary key default gen_random_uuid(),
+  customer_id uuid not null references public.customers(id) on delete cascade,
+  number text not null,
+  note text,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.work_orders (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  number text not null,
+  type text not null check (type in ('Build', 'Onsite')),
+  note text,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.purchase_orders (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null references public.projects(id) on delete cascade,
+  number text not null,
+  note text,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists projects_customer_id_idx on public.projects(customer_id);
+create unique index if not exists projects_customer_number_key on public.projects(customer_id, number);
+
+create index if not exists work_orders_project_id_idx on public.work_orders(project_id);
+create unique index if not exists work_orders_project_number_key on public.work_orders(project_id, number);
+
+create index if not exists purchase_orders_project_id_idx on public.purchase_orders(project_id);
+create unique index if not exists purchase_orders_project_number_key on public.purchase_orders(project_id, number);
+
+alter table public.customers enable row level security;
+alter table public.projects enable row level security;
+alter table public.work_orders enable row level security;
+alter table public.purchase_orders enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Allow public read customers'
+  ) then
+    create policy "Allow public read customers" on public.customers for select using (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Allow public insert customers'
+  ) then
+    create policy "Allow public insert customers" on public.customers for insert with check (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Allow public update customers'
+  ) then
+    create policy "Allow public update customers" on public.customers for update using (true) with check (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Allow public delete customers'
+  ) then
+    create policy "Allow public delete customers" on public.customers for delete using (true);
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Allow public read projects'
+  ) then
+    create policy "Allow public read projects" on public.projects for select using (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Allow public insert projects'
+  ) then
+    create policy "Allow public insert projects" on public.projects for insert with check (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Allow public update projects'
+  ) then
+    create policy "Allow public update projects" on public.projects for update using (true) with check (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Allow public delete projects'
+  ) then
+    create policy "Allow public delete projects" on public.projects for delete using (true);
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Allow public read work_orders'
+  ) then
+    create policy "Allow public read work_orders" on public.work_orders for select using (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Allow public insert work_orders'
+  ) then
+    create policy "Allow public insert work_orders" on public.work_orders for insert with check (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Allow public update work_orders'
+  ) then
+    create policy "Allow public update work_orders" on public.work_orders for update using (true) with check (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Allow public delete work_orders'
+  ) then
+    create policy "Allow public delete work_orders" on public.work_orders for delete using (true);
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Allow public read purchase_orders'
+  ) then
+    create policy "Allow public read purchase_orders" on public.purchase_orders for select using (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Allow public insert purchase_orders'
+  ) then
+    create policy "Allow public insert purchase_orders" on public.purchase_orders for insert with check (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Allow public update purchase_orders'
+  ) then
+    create policy "Allow public update purchase_orders" on public.purchase_orders for update using (true) with check (true);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Allow public delete purchase_orders'
+  ) then
+    create policy "Allow public delete purchase_orders" on public.purchase_orders for delete using (true);
+  end if;
+end;
+$$;


### PR DESCRIPTION
## Summary
- add a storage provider flag and UI badge to indicate when Supabase is active and warn when it is not configured
- document the Supabase setup workflow and provide an `.env.example` template for the required environment variables
- add a Supabase schema SQL script with tables, indexes and RLS policies for the app tables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1143763a883219e038307ee72e503