### PR TITLE
feat: require Supabase sign-in and secure storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ By default data is stored in the browser `localStorage` under key `cpdb.v1`.
 To use a shared Supabase database instead:
 
 1. Create a Supabase project and run [`supabase/schema.sql`](supabase/schema.sql)
-   to create tables and policies.
+   to create the tables, ownership columns, and secure Row Level Security policies.
 2. Copy `.env.example` to `.env.local` (or set the variables another way) and
    provide values for `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.
+3. Create user accounts through the Supabase dashboard (email/password) and
+   use those credentials to sign in from the app.
 
-Once configured the UI will display **Storage: Supabase** and all reads/writes
-go through Supabase. See [supabase/README.md](supabase/README.md) for more
-details.
+Once configured the UI will require authentication and show **Storage: Supabase**
+for signed-in users. Data is stored per account in Supabase; otherwise the app
+continues to fall back to local browser storage.
 
 
 ## GitHub Setup

--- a/src/lib/useSupabaseAuth.ts
+++ b/src/lib/useSupabaseAuth.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { Session, User } from '@supabase/supabase-js'
+import { getSupabaseClient, isSupabaseConfigured } from './supabase'
+
+type AuthStatus = 'disabled' | 'loading' | 'signed-out' | 'signed-in' | 'error'
+
+type AuthState =
+  | { status: 'disabled' }
+  | { status: 'loading' }
+  | { status: 'signed-out' }
+  | { status: 'signed-in'; session: Session; user: User }
+  | { status: 'error'; message: string }
+
+type AuthResult = {
+  status: AuthStatus
+  session: Session | null
+  user: User | null
+  error: string | null
+  signIn(email: string, password: string): Promise<{ error: string | null }>
+  signUp(email: string, password: string): Promise<{ error: string | null; confirmationRequired: boolean }>
+  signOut(): Promise<{ error: string | null }>
+}
+
+export function useSupabaseAuth(enabled: boolean): AuthResult {
+  const supabaseEnabled = enabled && isSupabaseConfigured()
+  const [state, setState] = useState<AuthState>(() => (supabaseEnabled ? { status: 'loading' } : { status: 'disabled' }))
+
+  useEffect(() => {
+    if (!supabaseEnabled) {
+      setState({ status: 'disabled' })
+      return
+    }
+
+    const client = getSupabaseClient()
+    let mounted = true
+
+    setState({ status: 'loading' })
+
+    client.auth
+      .getSession()
+      .then(({ data, error }) => {
+        if (!mounted) return
+        if (error) {
+          setState({ status: 'error', message: error.message })
+          return
+        }
+        const session = data.session
+        if (session) {
+          setState({ status: 'signed-in', session, user: session.user })
+        } else {
+          setState({ status: 'signed-out' })
+        }
+      })
+      .catch(error => {
+        if (!mounted) return
+        const message = error instanceof Error ? error.message : 'Unknown authentication error.'
+        setState({ status: 'error', message })
+      })
+
+    const {
+      data: { subscription },
+    } = client.auth.onAuthStateChange((_event, session) => {
+      if (!mounted) return
+      if (session) {
+        setState({ status: 'signed-in', session, user: session.user })
+      } else {
+        setState({ status: 'signed-out' })
+      }
+    })
+
+    return () => {
+      mounted = false
+      subscription.unsubscribe()
+    }
+  }, [supabaseEnabled])
+
+  const signIn = useCallback(async (email: string, password: string) => {
+    if (!supabaseEnabled) {
+      return { error: 'Supabase is not enabled.' }
+    }
+
+    const client = getSupabaseClient()
+    const { error } = await client.auth.signInWithPassword({ email, password })
+    return { error: error ? error.message : null }
+  }, [supabaseEnabled])
+
+  const signUp = useCallback(async (email: string, password: string) => {
+    if (!supabaseEnabled) {
+      return { error: 'Supabase is not enabled.', confirmationRequired: false }
+    }
+
+    const client = getSupabaseClient()
+    const { data, error } = await client.auth.signUp({ email, password })
+    return { error: error ? error.message : null, confirmationRequired: !data.session }
+  }, [supabaseEnabled])
+
+  const signOut = useCallback(async () => {
+    if (!supabaseEnabled) {
+      return { error: 'Supabase is not enabled.' }
+    }
+
+    const client = getSupabaseClient()
+    const { error } = await client.auth.signOut()
+    return { error: error ? error.message : null }
+  }, [supabaseEnabled])
+
+  const status: AuthStatus = useMemo(() => {
+    if (!supabaseEnabled) return 'disabled'
+    return state.status
+  }, [state.status, supabaseEnabled])
+
+  const session = state.status === 'signed-in' ? state.session : null
+  const user = state.status === 'signed-in' ? state.user : null
+  const error = state.status === 'error' ? state.message : null
+
+  return { status, session, user, error, signIn, signUp, signOut }
+}

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -7,10 +7,12 @@ Follow these steps to prepare a project:
    database to provision.
 2. Open the SQL Editor and run [`schema.sql`](./schema.sql). The script creates
    the tables (`customers`, `projects`, `work_orders`, `purchase_orders`),
-   foreign keys, indexes, and permissive Row Level Security policies that allow
-   the anonymous key to read/write data.
+   per-account ownership columns, indexes, and Row Level Security policies that
+   scope every query to the signed-in user.
 3. In the Supabase dashboard copy the Project URL and the `anon` public API key.
-4. Copy `.env.example` to `.env.local` in the project root (or otherwise
+4. Create email/password users in the Supabase Auth dashboard. Each user gets a
+   private set of customers/projects/work orders in the app.
+5. Copy `.env.example` to `.env.local` in the project root (or otherwise
    provide the variables) with:
 
    ```bash
@@ -18,9 +20,9 @@ Follow these steps to prepare a project:
    VITE_SUPABASE_ANON_KEY="YOUR_ANON_KEY"
    ```
 
-5. Restart `npm run dev` (or rebuild for production). When the variables are
-   present the UI will show "Storage: Supabase" and data will be saved to the
-   remote database.
+6. Restart `npm run dev` (or rebuild for production). When the variables are
+   present the UI will show "Storage: Supabase" and require sign-in before
+   loading data from the remote database.
 
 The script is idempotent so you can re-run it to refresh the policies. To remove
 all data simply truncate the tables in Supabase or use the dashboard to delete

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -7,6 +7,7 @@ create extension if not exists "pgcrypto";
 
 create table if not exists public.customers (
   id uuid primary key default gen_random_uuid(),
+  owner_id uuid references auth.users(id) default auth.uid(),
   name text not null,
   address text,
   contact_name text,
@@ -17,6 +18,7 @@ create table if not exists public.customers (
 
 create table if not exists public.projects (
   id uuid primary key default gen_random_uuid(),
+  owner_id uuid references auth.users(id) default auth.uid(),
   customer_id uuid not null references public.customers(id) on delete cascade,
   number text not null,
   note text,
@@ -25,6 +27,7 @@ create table if not exists public.projects (
 
 create table if not exists public.work_orders (
   id uuid primary key default gen_random_uuid(),
+  owner_id uuid references auth.users(id) default auth.uid(),
   project_id uuid not null references public.projects(id) on delete cascade,
   number text not null,
   type text not null check (type in ('Build', 'Onsite')),
@@ -34,11 +37,28 @@ create table if not exists public.work_orders (
 
 create table if not exists public.purchase_orders (
   id uuid primary key default gen_random_uuid(),
+  owner_id uuid references auth.users(id) default auth.uid(),
   project_id uuid not null references public.projects(id) on delete cascade,
   number text not null,
   note text,
   created_at timestamptz not null default timezone('utc', now())
 );
+
+alter table public.customers add column if not exists owner_id uuid references auth.users(id);
+alter table public.projects add column if not exists owner_id uuid references auth.users(id);
+alter table public.work_orders add column if not exists owner_id uuid references auth.users(id);
+alter table public.purchase_orders add column if not exists owner_id uuid references auth.users(id);
+
+alter table public.customers alter column owner_id set default auth.uid();
+alter table public.projects alter column owner_id set default auth.uid();
+alter table public.work_orders alter column owner_id set default auth.uid();
+alter table public.purchase_orders alter column owner_id set default auth.uid();
+
+create unique index if not exists customers_owner_name_key on public.customers(owner_id, lower(name));
+create index if not exists customers_owner_id_idx on public.customers(owner_id);
+create index if not exists projects_owner_id_idx on public.projects(owner_id);
+create index if not exists work_orders_owner_id_idx on public.work_orders(owner_id);
+create index if not exists purchase_orders_owner_id_idx on public.purchase_orders(owner_id);
 
 create index if not exists projects_customer_id_idx on public.projects(customer_id);
 create unique index if not exists projects_customer_number_key on public.projects(customer_id, number);
@@ -54,27 +74,55 @@ alter table public.projects enable row level security;
 alter table public.work_orders enable row level security;
 alter table public.purchase_orders enable row level security;
 
+-- Remove legacy permissive policies if they exist
+
+drop policy if exists "Allow public read customers" on public.customers;
+drop policy if exists "Allow public insert customers" on public.customers;
+drop policy if exists "Allow public update customers" on public.customers;
+drop policy if exists "Allow public delete customers" on public.customers;
+
+drop policy if exists "Allow public read projects" on public.projects;
+drop policy if exists "Allow public insert projects" on public.projects;
+drop policy if exists "Allow public update projects" on public.projects;
+drop policy if exists "Allow public delete projects" on public.projects;
+
+drop policy if exists "Allow public read work_orders" on public.work_orders;
+drop policy if exists "Allow public insert work_orders" on public.work_orders;
+drop policy if exists "Allow public update work_orders" on public.work_orders;
+drop policy if exists "Allow public delete work_orders" on public.work_orders;
+
+drop policy if exists "Allow public read purchase_orders" on public.purchase_orders;
+drop policy if exists "Allow public insert purchase_orders" on public.purchase_orders;
+drop policy if exists "Allow public update purchase_orders" on public.purchase_orders;
+drop policy if exists "Allow public delete purchase_orders" on public.purchase_orders;
+
+-- Policies per table
+
 do $$
 begin
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Allow public read customers'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Users can read own customers'
   ) then
-    create policy "Allow public read customers" on public.customers for select using (true);
+    create policy "Users can read own customers" on public.customers
+      for select using (owner_id = auth.uid());
   end if;
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Allow public insert customers'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Users can insert own customers'
   ) then
-    create policy "Allow public insert customers" on public.customers for insert with check (true);
+    create policy "Users can insert own customers" on public.customers
+      for insert with check (owner_id = auth.uid());
   end if;
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Allow public update customers'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Users can update own customers'
   ) then
-    create policy "Allow public update customers" on public.customers for update using (true) with check (true);
+    create policy "Users can update own customers" on public.customers
+      for update using (owner_id = auth.uid()) with check (owner_id = auth.uid());
   end if;
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Allow public delete customers'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'customers' and policyname = 'Users can delete own customers'
   ) then
-    create policy "Allow public delete customers" on public.customers for delete using (true);
+    create policy "Users can delete own customers" on public.customers
+      for delete using (owner_id = auth.uid());
   end if;
 end;
 $$;
@@ -82,49 +130,37 @@ $$;
 do $$
 begin
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Allow public read projects'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Users can read own projects'
   ) then
-    create policy "Allow public read projects" on public.projects for select using (true);
+    create policy "Users can read own projects" on public.projects
+      for select using (owner_id = auth.uid());
   end if;
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Allow public insert projects'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Users can insert own projects'
   ) then
-    create policy "Allow public insert projects" on public.projects for insert with check (true);
+    create policy "Users can insert own projects" on public.projects
+      for insert
+      with check (
+        owner_id = auth.uid()
+        and customer_id in (select id from public.customers where owner_id = auth.uid())
+      );
   end if;
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Allow public update projects'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Users can update own projects'
   ) then
-    create policy "Allow public update projects" on public.projects for update using (true) with check (true);
+    create policy "Users can update own projects" on public.projects
+      for update
+      using (owner_id = auth.uid())
+      with check (
+        owner_id = auth.uid()
+        and customer_id in (select id from public.customers where owner_id = auth.uid())
+      );
   end if;
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Allow public delete projects'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'projects' and policyname = 'Users can delete own projects'
   ) then
-    create policy "Allow public delete projects" on public.projects for delete using (true);
-  end if;
-end;
-$$;
-
-do $$
-begin
-  if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Allow public read work_orders'
-  ) then
-    create policy "Allow public read work_orders" on public.work_orders for select using (true);
-  end if;
-  if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Allow public insert work_orders'
-  ) then
-    create policy "Allow public insert work_orders" on public.work_orders for insert with check (true);
-  end if;
-  if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Allow public update work_orders'
-  ) then
-    create policy "Allow public update work_orders" on public.work_orders for update using (true) with check (true);
-  end if;
-  if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Allow public delete work_orders'
-  ) then
-    create policy "Allow public delete work_orders" on public.work_orders for delete using (true);
+    create policy "Users can delete own projects" on public.projects
+      for delete using (owner_id = auth.uid());
   end if;
 end;
 $$;
@@ -132,24 +168,75 @@ $$;
 do $$
 begin
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Allow public read purchase_orders'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Users can read own work_orders'
   ) then
-    create policy "Allow public read purchase_orders" on public.purchase_orders for select using (true);
+    create policy "Users can read own work_orders" on public.work_orders
+      for select using (owner_id = auth.uid());
   end if;
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Allow public insert purchase_orders'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Users can insert own work_orders'
   ) then
-    create policy "Allow public insert purchase_orders" on public.purchase_orders for insert with check (true);
+    create policy "Users can insert own work_orders" on public.work_orders
+      for insert
+      with check (
+        owner_id = auth.uid()
+        and project_id in (select id from public.projects where owner_id = auth.uid())
+      );
   end if;
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Allow public update purchase_orders'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Users can update own work_orders'
   ) then
-    create policy "Allow public update purchase_orders" on public.purchase_orders for update using (true) with check (true);
+    create policy "Users can update own work_orders" on public.work_orders
+      for update
+      using (owner_id = auth.uid())
+      with check (
+        owner_id = auth.uid()
+        and project_id in (select id from public.projects where owner_id = auth.uid())
+      );
   end if;
   if not exists (
-    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Allow public delete purchase_orders'
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'work_orders' and policyname = 'Users can delete own work_orders'
   ) then
-    create policy "Allow public delete purchase_orders" on public.purchase_orders for delete using (true);
+    create policy "Users can delete own work_orders" on public.work_orders
+      for delete using (owner_id = auth.uid());
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Users can read own purchase_orders'
+  ) then
+    create policy "Users can read own purchase_orders" on public.purchase_orders
+      for select using (owner_id = auth.uid());
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Users can insert own purchase_orders'
+  ) then
+    create policy "Users can insert own purchase_orders" on public.purchase_orders
+      for insert
+      with check (
+        owner_id = auth.uid()
+        and project_id in (select id from public.projects where owner_id = auth.uid())
+      );
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Users can update own purchase_orders'
+  ) then
+    create policy "Users can update own purchase_orders" on public.purchase_orders
+      for update
+      using (owner_id = auth.uid())
+      with check (
+        owner_id = auth.uid()
+        and project_id in (select id from public.projects where owner_id = auth.uid())
+      );
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'purchase_orders' and policyname = 'Users can delete own purchase_orders'
+  ) then
+    create policy "Users can delete own purchase_orders" on public.purchase_orders
+      for delete using (owner_id = auth.uid());
   end if;
 end;
 $$;


### PR DESCRIPTION
## Summary
- add a Supabase auth hook and require signing in before the app loads remote data
- secure Supabase storage calls with per-user filters and update the schema with owner columns and RLS policies
- refresh Supabase documentation to describe the new authentication flow and browser fallback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d11be4963483218fa0610112c0fc44