### PR TITLE
Add Supabase auth roles and admin tooling

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -13,7 +13,8 @@ export default function Button({
   children,
   ...props
 }: Props) {
-  const base = 'inline-flex items-center gap-2 rounded-2xl border px-3 py-2 text-sm font-medium shadow-sm transition active:scale-[.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500'
+  const base =
+    'inline-flex items-center gap-2 rounded-2xl border px-3 py-2 text-sm font-medium shadow-sm transition active:scale-[.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 disabled:cursor-not-allowed disabled:opacity-60 disabled:shadow-none'
   const v =
     variant === 'outline'
       ? 'border-slate-200/80 bg-white/80 text-slate-700 hover:bg-white hover:border-slate-300'

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,0 +1,152 @@
+import type { Session } from '@supabase/supabase-js'
+import { getSupabaseClient } from './supabase'
+import type { AppRole } from '../types'
+
+type RoleRow = { role: string | null }
+
+export type ManagedUser = {
+  id: string
+  email: string | null
+  roles: AppRole[]
+  createdAt: string | null
+  lastSignInAt: string | null
+}
+
+const VALID_ROLES: AppRole[] = ['admin', 'editor', 'viewer']
+
+function normalizeRole(value: unknown): AppRole | null {
+  if (typeof value !== 'string') return null
+  const lower = value.toLowerCase()
+  return VALID_ROLES.find(role => role === lower) ?? null
+}
+
+function sortRoles(roles: AppRole[]): AppRole[] {
+  const order = new Map<AppRole, number>([
+    ['admin', 0],
+    ['editor', 1],
+    ['viewer', 2],
+  ])
+  return [...roles].sort((a, b) => (order.get(a) ?? 99) - (order.get(b) ?? 99))
+}
+
+export function isRlsError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const message = error.message.toLowerCase()
+  return (
+    message.includes('row level security') ||
+    message.includes('new row violates row-level security policy') ||
+    message.includes('violates row level security policy') ||
+    message.includes('permission denied') ||
+    message.includes('not authorized')
+  )
+}
+
+export function getFriendlySupabaseError(
+  error: unknown,
+  fallbackMessage: string,
+  unauthorizedMessage = 'Not authorized to perform this action.',
+): string {
+  if (isRlsError(error)) {
+    return unauthorizedMessage
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+
+  return fallbackMessage
+}
+
+export async function fetchCurrentUserRoles(): Promise<AppRole[]> {
+  const client = getSupabaseClient()
+  const { data, error } = await client.from('me_roles').select('role')
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  const seen = new Set<AppRole>()
+  for (const row of data as RoleRow[] | null ?? []) {
+    const normalized = normalizeRole(row?.role ?? null)
+    if (normalized) {
+      seen.add(normalized)
+    }
+  }
+
+  return sortRoles(Array.from(seen))
+}
+
+export async function fetchManagedUsers(session: Session): Promise<ManagedUser[]> {
+  if (!session?.access_token) {
+    throw new Error('A valid session token is required to load users.')
+  }
+
+  const client = getSupabaseClient()
+  const { data, error } = await client.functions.invoke('user-management', {
+    body: { action: 'list-users' },
+    headers: { Authorization: `Bearer ${session.access_token}` },
+  })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  const rows: unknown = (data as { users?: unknown })?.users ?? data
+
+  if (!Array.isArray(rows)) {
+    return []
+  }
+
+  return rows
+    .map(row => {
+      const id = typeof row?.id === 'string' ? row.id : ''
+      const email = typeof row?.email === 'string' ? row.email : null
+      const createdAt = typeof row?.created_at === 'string' ? row.created_at : null
+      const lastSignInAt = typeof row?.last_sign_in_at === 'string' ? row.last_sign_in_at : null
+      const roleValues: unknown = Array.isArray(row?.roles) ? row.roles : []
+      const normalizedRoles = Array.isArray(roleValues)
+        ? sortRoles(
+            roleValues
+              .map(normalizeRole)
+              .filter((role): role is AppRole => !!role),
+          )
+        : []
+
+      return {
+        id,
+        email,
+        createdAt,
+        lastSignInAt,
+        roles: normalizedRoles,
+      }
+    })
+    .filter(user => user.id)
+}
+
+export async function updateUserRole(
+  session: Session,
+  payload: { email: string; role: AppRole; action: 'grant' | 'revoke' },
+): Promise<{ message: string }> {
+  if (!session?.access_token) {
+    throw new Error('A valid session token is required to update roles.')
+  }
+
+  const client = getSupabaseClient()
+  const { data, error } = await client.functions.invoke('user-management', {
+    body: { action: 'update-role', email: payload.email, role: payload.role, mode: payload.action },
+    headers: { Authorization: `Bearer ${session.access_token}` },
+  })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  const message =
+    typeof (data as { message?: unknown })?.message === 'string'
+      ? (data as { message?: string }).message
+      : payload.action === 'grant'
+        ? 'Role granted successfully.'
+        : 'Role revoked successfully.'
+
+  return { message }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,3 +30,5 @@ export type Customer = {
   contactEmail?: string;
   projects: Project[];
 };
+
+export type AppRole = 'viewer' | 'editor' | 'admin';

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -24,6 +24,27 @@ Follow these steps to prepare a project:
    present the UI will show "Storage: Supabase" and require sign-in before
    loading data from the remote database.
 
+## Roles and user management
+
+The SQL script now provisions a `user_roles` table, a `me_roles` view, and a
+`grant_role_by_email` helper so the front-end can enable role-aware experiences.
+
+To expose the admin APIs, deploy the bundled Supabase Edge Function:
+
+```bash
+supabase functions deploy user-management --project-ref YOUR_PROJECT_REF
+```
+
+The function must run with the `service_role` key (Supabase automatically
+injects this at runtime) and enforces that only users with the `admin` role can
+list accounts or grant/revoke roles. The UI invokes the function via
+`supabase.functions.invoke('user-management', …)`.
+
+Assign roles to users (e.g. `viewer`, `editor`, `admin`) from the "Manage Users"
+screen or by calling `select grant_role_by_email('user@example.com', 'editor',
+true);` in the SQL editor. Viewers get read-only access, editors/admins can
+mutate data, and admin accounts can manage other users.
+
 The script is idempotent so you can re-run it to refresh the policies. To remove
 all data simply truncate the tables in Supabase or use the dashboard to delete
 rows.

--- a/supabase/functions/user-management/index.ts
+++ b/supabase/functions/user-management/index.ts
@@ -1,0 +1,164 @@
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.57.4?dts'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
+type AppRole = 'viewer' | 'editor' | 'admin'
+
+function normalizeRole(value: unknown): AppRole | null {
+  if (typeof value !== 'string') return null
+  const lower = value.toLowerCase()
+  if (lower === 'viewer' || lower === 'editor' || lower === 'admin') {
+    return lower
+  }
+  return null
+}
+
+serve(async req => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405, headers: corsHeaders })
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return new Response('Service not configured.', { status: 500, headers: corsHeaders })
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? ''
+  const token = authHeader.replace('Bearer ', '').trim()
+
+  if (!token) {
+    return new Response('Missing authorization token.', { status: 401, headers: corsHeaders })
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  })
+
+  const {
+    data: userResult,
+    error: userError,
+  } = await supabase.auth.getUser(token)
+
+  if (userError || !userResult?.user) {
+    return new Response('Unauthorized.', { status: 401, headers: corsHeaders })
+  }
+
+  const actor = userResult.user
+  const { data: roleRows, error: rolesError } = await supabase
+    .from('user_roles')
+    .select('role')
+    .eq('user_id', actor.id)
+
+  if (rolesError) {
+    return new Response('Unable to verify roles.', { status: 500, headers: corsHeaders })
+  }
+
+  const actorRoles = (roleRows ?? [])
+    .map(row => normalizeRole((row as { role?: string | null })?.role ?? null))
+    .filter((role): role is AppRole => !!role)
+
+  if (!actorRoles.includes('admin')) {
+    return new Response('Forbidden.', { status: 403, headers: corsHeaders })
+  }
+
+  let body: any
+  try {
+    body = await req.json()
+  } catch (_error) {
+    return new Response('Invalid JSON body.', { status: 400, headers: corsHeaders })
+  }
+
+  const action = typeof body?.action === 'string' ? body.action : ''
+
+  if (action === 'list-users') {
+    const {
+      data: listResult,
+      error: listError,
+    } = await supabase.auth.admin.listUsers({ page: 1, perPage: 1000 })
+
+    if (listError) {
+      return new Response('Failed to list users.', { status: 500, headers: corsHeaders })
+    }
+
+    const users = listResult?.users ?? []
+    const userIds = users.map(user => user.id)
+
+    const {
+      data: allRoles,
+      error: allRolesError,
+    } = await supabase
+      .from('user_roles')
+      .select('user_id, role')
+      .in('user_id', userIds.length > 0 ? userIds : ['00000000-0000-0000-0000-000000000000'])
+
+    if (allRolesError) {
+      return new Response('Failed to load user roles.', { status: 500, headers: corsHeaders })
+    }
+
+    const roleMap = new Map<string, AppRole[]>()
+    for (const entry of allRoles ?? []) {
+      const userId = typeof (entry as { user_id?: string | null }).user_id === 'string' ? (entry as any).user_id : null
+      const role = normalizeRole((entry as { role?: string | null }).role ?? null)
+      if (!userId || !role) continue
+      const current = roleMap.get(userId) ?? []
+      if (!current.includes(role)) {
+        current.push(role)
+        roleMap.set(userId, current)
+      }
+    }
+
+    const responseUsers = users.map(user => ({
+      id: user.id,
+      email: user.email ?? null,
+      created_at: user.created_at ?? null,
+      last_sign_in_at: user.last_sign_in_at ?? null,
+      roles: roleMap.get(user.id) ?? [],
+    }))
+
+    return new Response(JSON.stringify({ users: responseUsers }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  }
+
+  if (action === 'update-role') {
+    const email = typeof body?.email === 'string' ? body.email.trim() : ''
+    const role = normalizeRole(body?.role)
+    const mode = body?.mode === 'grant' ? 'grant' : body?.mode === 'revoke' ? 'revoke' : null
+
+    if (!email || !role || !mode) {
+      return new Response('Email, role, and mode are required.', { status: 400, headers: corsHeaders })
+    }
+
+    const { error: rpcError } = await supabase.rpc('grant_role_by_email', {
+      target_email: email,
+      target_role: role,
+      should_grant: mode === 'grant',
+      performed_by: actor.id,
+    })
+
+    if (rpcError) {
+      return new Response(rpcError.message ?? 'Role update failed.', { status: 400, headers: corsHeaders })
+    }
+
+    const message = mode === 'grant' ? `Granted ${role} role.` : `Revoked ${role} role.`
+
+    return new Response(JSON.stringify({ message }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  }
+
+  return new Response('Unknown action.', { status: 400, headers: corsHeaders })
+})


### PR DESCRIPTION
## Summary
- fetch Supabase roles on sign-in and gate editing features plus new admin user management panel
- add role helpers and function invocation utilities along with a Supabase Edge Function for listing/updating user roles
- extend the Supabase schema and docs with user_roles table, me_roles view, and grant_role_by_email helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d134195f1c8321853a4067f40410eb