### PR TITLE
refactor: use Supabase storage only

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,6 +1,7 @@
 import type { PostgrestError, SupabaseClient } from '@supabase/supabase-js'
 import type { Customer, PO, Project, WO, WOType } from '../types'
 import { getSupabaseClient, isSupabaseConfigured } from './supabase'
+import { extractSupabaseErrorMessage, isSupabaseUnavailableError } from './supabaseErrors'
 
 type StorageApi = {
   listCustomers(): Promise<Customer[]>
@@ -34,95 +35,89 @@ type StorageApi = {
   deletePO(poId: string): Promise<void>
 }
 
-export type StorageProvider = 'supabase' | 'browser'
-export type StorageProviderChangeReason = 'supabase-unavailable'
-export type StorageProviderChange = {
-  provider: StorageProvider
-  reason?: StorageProviderChangeReason
-  error?: Error
-}
+let supabaseStorage: StorageApi | null = null
 
-const browserStorage = createBrowserStorage()
-const supabaseConfigured = isSupabaseConfigured()
-const supabaseStorage = supabaseConfigured ? createSupabaseStorage(getSupabaseClient()) : null
-
-let currentProvider: StorageProvider = supabaseConfigured ? 'supabase' : 'browser'
-let storage: StorageApi = supabaseStorage ?? browserStorage
-
-const storageProviderListeners = new Set<(change: StorageProviderChange) => void>()
-
-function notifyProviderChange(change: StorageProviderChange): void {
-  storageProviderListeners.forEach(listener => {
-    try {
-      listener(change)
-    } catch (error) {
-      console.error('Storage provider listener failed', error)
-    }
-  })
-}
-
-function isSupabaseUnavailableError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false
+function ensureSupabaseStorage(): StorageApi {
+  if (!isSupabaseConfigured()) {
+    throw new Error(
+      'Supabase client is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable Supabase storage.',
+    )
   }
 
-  const message = error.message.toLowerCase()
+  if (!supabaseStorage) {
+    supabaseStorage = createSupabaseStorage(getSupabaseClient())
+  }
 
+  return supabaseStorage
+}
+
+function isRlsMessage(message: string): boolean {
+  const normalized = message.toLowerCase()
   return (
-    message.includes('fetch failed') ||
-    message.includes('failed to fetch') ||
-    message.includes('network request failed') ||
-    message.includes('getaddrinfo') ||
-    message.includes('etimedout') ||
-    message.includes('ecconnreset') ||
-    message.includes('ssl connect error') ||
-    message.includes('certificate')
+    normalized.includes('row level security') ||
+    normalized.includes('row-level security') ||
+    normalized.includes('permission denied') ||
+    normalized.includes('not authorized')
   )
 }
 
-function switchToBrowserStorage(reason?: StorageProviderChangeReason, error?: Error): void {
-  if (currentProvider === 'browser') {
-    return
+function normalizeStorageError(error: unknown, fallbackMessage: string): Error {
+  if (isSupabaseUnavailableError(error)) {
+    return new Error('Unable to reach Supabase right now. Please check your connection and try again.')
   }
 
-  currentProvider = 'browser'
-  storage = browserStorage
-  notifyProviderChange({ provider: currentProvider, reason, error })
+  if (error instanceof Error) {
+    if (isRlsMessage(error.message)) {
+      return new Error('Not authorized to perform this action.')
+    }
+    return error
+  }
+
+  const extracted = extractSupabaseErrorMessage(error)
+  if (extracted) {
+    if (isRlsMessage(extracted)) {
+      return new Error('Not authorized to perform this action.')
+    }
+    return new Error(extracted)
+  }
+
+  return new Error(fallbackMessage)
 }
 
-async function runWithStorage<T>(operation: (active: StorageApi) => Promise<T>): Promise<T> {
+async function runWithSupabase<T>(operation: () => Promise<T>, fallbackMessage: string): Promise<T> {
   try {
-    return await operation(storage)
+    return await operation()
   } catch (error) {
-    if (currentProvider === 'supabase' && isSupabaseUnavailableError(error)) {
-      const fallbackError = error instanceof Error ? error : new Error(String(error))
-      console.warn('Supabase request failed. Falling back to browser storage.', fallbackError)
-      switchToBrowserStorage('supabase-unavailable', fallbackError)
-      return operation(storage)
-    }
-
-    if (error instanceof Error) {
-      throw error
-    }
-
-    throw new Error(String(error))
+    throw normalizeStorageError(error, fallbackMessage)
   }
 }
 
 export function listCustomers(): Promise<Customer[]> {
-  return runWithStorage(active => active.listCustomers())
+  return runWithSupabase(
+    () => ensureSupabaseStorage().listCustomers(),
+    'Unable to load customers from Supabase.',
+  )
 }
 
 export function listProjectsByCustomer(customerId: string): Promise<Project[]> {
-  return runWithStorage(active => active.listProjectsByCustomer(customerId))
+  return runWithSupabase(
+    () => ensureSupabaseStorage().listProjectsByCustomer(customerId),
+    'Unable to load projects from Supabase.',
+  )
 }
 
 export function listWOs(projectId: string): Promise<WO[]> {
-  return runWithStorage(active => active.listWOs(projectId))
+  return runWithSupabase(
+    () => ensureSupabaseStorage().listWOs(projectId),
+    'Unable to load work orders from Supabase.',
+  )
 }
 
 export function listPOs(projectId: string): Promise<PO[]> {
-  return runWithStorage(active => active.listPOs(projectId))
+  return runWithSupabase(
+    () => ensureSupabaseStorage().listPOs(projectId),
+    'Unable to load purchase orders from Supabase.',
+  )
 }
 
 export function createCustomer(data: {
@@ -132,7 +127,10 @@ export function createCustomer(data: {
   contactPhone?: string
   contactEmail?: string
 }): Promise<Customer> {
-  return runWithStorage(active => active.createCustomer(data))
+  return runWithSupabase(
+    () => ensureSupabaseStorage().createCustomer(data),
+    'Failed to create customer.',
+  )
 }
 
 export function updateCustomer(
@@ -145,55 +143,57 @@ export function updateCustomer(
     contactEmail?: string | null
   },
 ): Promise<Customer> {
-  return runWithStorage(active => active.updateCustomer(customerId, data))
+  return runWithSupabase(
+    () => ensureSupabaseStorage().updateCustomer(customerId, data),
+    'Failed to update customer.',
+  )
 }
 
 export function deleteCustomer(customerId: string): Promise<void> {
-  return runWithStorage(active => active.deleteCustomer(customerId))
+  return runWithSupabase(() => ensureSupabaseStorage().deleteCustomer(customerId), 'Failed to delete customer.')
 }
 
 export function createProject(customerId: string, number: string): Promise<Project> {
-  return runWithStorage(active => active.createProject(customerId, number))
+  return runWithSupabase(
+    () => ensureSupabaseStorage().createProject(customerId, number),
+    'Failed to create project.',
+  )
 }
 
 export function updateProject(projectId: string, data: { note?: string | null }): Promise<Project> {
-  return runWithStorage(active => active.updateProject(projectId, data))
+  return runWithSupabase(
+    () => ensureSupabaseStorage().updateProject(projectId, data),
+    'Failed to update project.',
+  )
 }
 
 export function deleteProject(projectId: string): Promise<void> {
-  return runWithStorage(active => active.deleteProject(projectId))
+  return runWithSupabase(() => ensureSupabaseStorage().deleteProject(projectId), 'Failed to delete project.')
 }
 
 export function createWO(
   projectId: string,
   data: { number: string; type: WOType; note?: string },
 ): Promise<WO> {
-  return runWithStorage(active => active.createWO(projectId, data))
+  return runWithSupabase(
+    () => ensureSupabaseStorage().createWO(projectId, data),
+    'Failed to create work order.',
+  )
 }
 
 export function deleteWO(woId: string): Promise<void> {
-  return runWithStorage(active => active.deleteWO(woId))
+  return runWithSupabase(() => ensureSupabaseStorage().deleteWO(woId), 'Failed to delete work order.')
 }
 
 export function createPO(projectId: string, data: { number: string; note?: string }): Promise<PO> {
-  return runWithStorage(active => active.createPO(projectId, data))
+  return runWithSupabase(
+    () => ensureSupabaseStorage().createPO(projectId, data),
+    'Failed to create purchase order.',
+  )
 }
 
 export function deletePO(poId: string): Promise<void> {
-  return runWithStorage(active => active.deletePO(poId))
-}
-
-export function getStorageProvider(): StorageProvider {
-  return currentProvider
-}
-
-export function subscribeToStorageProviderChange(
-  listener: (change: StorageProviderChange) => void,
-): () => void {
-  storageProviderListeners.add(listener)
-  return () => {
-    storageProviderListeners.delete(listener)
-  }
+  return runWithSupabase(() => ensureSupabaseStorage().deletePO(poId), 'Failed to delete purchase order.')
 }
 
 function sortByText<T>(items: T[], getValue: (item: T) => string): T[] {
@@ -607,441 +607,6 @@ function createSupabaseStorage(client: SupabaseClient): StorageApi {
       const userId = await requireUserId()
       const { error } = await client.from('purchase_orders').delete().eq('id', poId).eq('owner_id', userId)
       requireNoError(error)
-    },
-  }
-}
-
-function createBrowserStorage(): StorageApi {
-  const STORAGE_KEY = 'cpdb.v1'
-
-  type StorageLike = {
-    getItem(key: string): string | null
-    setItem(key: string, value: string): void
-    removeItem(key: string): void
-  }
-
-  const memoryStore: Record<string, string> = Object.create(null)
-
-  function getStorage(): StorageLike {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      return window.localStorage
-    }
-
-    return {
-      getItem(key) {
-        return Object.prototype.hasOwnProperty.call(memoryStore, key) ? memoryStore[key] : null
-      },
-      setItem(key, value) {
-        memoryStore[key] = value
-      },
-      removeItem(key) {
-        delete memoryStore[key]
-      },
-    }
-  }
-
-  const store = getStorage()
-
-  function read(): Customer[] {
-    const raw = store.getItem(STORAGE_KEY)
-    if (!raw) {
-      return []
-    }
-
-    try {
-      const parsed = JSON.parse(raw) as unknown
-      return normalizeCustomers(parsed)
-    } catch (error) {
-      console.warn('Failed to parse saved data. Resetting local cache.', error)
-      store.removeItem(STORAGE_KEY)
-      return []
-    }
-  }
-
-  function write(customers: Customer[]): void {
-    store.setItem(STORAGE_KEY, JSON.stringify(customers))
-  }
-
-  function generateId(prefix: string): string {
-    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-      return `${prefix}_${crypto.randomUUID()}`
-    }
-    const random = Math.random().toString(36).slice(2, 9)
-    const time = Date.now().toString(36).slice(-4)
-    return `${prefix}_${random}${time}`
-  }
-
-  function normalizeCustomers(value: unknown): Customer[] {
-    if (!Array.isArray(value)) {
-      return []
-    }
-
-    return value
-      .map(normalizeCustomer)
-      .map(customer => ({
-        ...customer,
-        projects: sortByText(customer.projects, project => project.number).map(project => ({
-          ...project,
-          wos: sortByText(project.wos, wo => wo.number),
-          pos: sortByText(project.pos, po => po.number),
-        })),
-      }))
-  }
-
-  function normalizeCustomer(value: any): Customer {
-    return {
-      id: typeof value?.id === 'string' ? value.id : generateId('cust'),
-      name: typeof value?.name === 'string' ? value.name : '',
-      address: typeof value?.address === 'string' ? value.address : undefined,
-      contactName: typeof value?.contactName === 'string' ? value.contactName : undefined,
-      contactPhone: typeof value?.contactPhone === 'string' ? value.contactPhone : undefined,
-      contactEmail: typeof value?.contactEmail === 'string' ? value.contactEmail : undefined,
-      projects: Array.isArray(value?.projects) ? value.projects.map(normalizeProject) : [],
-    }
-  }
-
-  function normalizeProject(value: any): Project {
-    const note = typeof value?.note === 'string' ? value.note : undefined
-    return {
-      id: typeof value?.id === 'string' ? value.id : generateId('proj'),
-      number: typeof value?.number === 'string' ? value.number : '',
-      note: note && note.trim().length > 0 ? note : undefined,
-      wos: Array.isArray(value?.wos) ? value.wos.map(normalizeWO) : [],
-      pos: Array.isArray(value?.pos) ? value.pos.map(normalizePO) : [],
-    }
-  }
-
-  function normalizeWO(value: any): WO {
-    const note = typeof value?.note === 'string' ? value.note : undefined
-    const type = value?.type === 'Onsite' ? 'Onsite' : 'Build'
-    return {
-      id: typeof value?.id === 'string' ? value.id : generateId('wo'),
-      number: typeof value?.number === 'string' ? value.number : '',
-      type,
-      note: note && note.trim().length > 0 ? note : undefined,
-    }
-  }
-
-  function normalizePO(value: any): PO {
-    const note = typeof value?.note === 'string' ? value.note : undefined
-    return {
-      id: typeof value?.id === 'string' ? value.id : generateId('po'),
-      number: typeof value?.number === 'string' ? value.number : '',
-      note: note && note.trim().length > 0 ? note : undefined,
-    }
-  }
-
-  function cloneCustomer(customer: Customer): Customer {
-    return {
-      ...customer,
-      projects: customer.projects.map(cloneProject),
-    }
-  }
-
-  function cloneProject(project: Project): Project {
-    return {
-      ...project,
-      wos: project.wos.map(cloneWO),
-      pos: project.pos.map(clonePO),
-    }
-  }
-
-  function cloneWO(wo: WO): WO {
-    return { ...wo }
-  }
-
-  function clonePO(po: PO): PO {
-    return { ...po }
-  }
-
-  function locateProject(db: Customer[], projectId: string): { customerIndex: number; projectIndex: number } | null {
-    for (let customerIndex = 0; customerIndex < db.length; customerIndex += 1) {
-      const projectIndex = db[customerIndex].projects.findIndex(project => project.id === projectId)
-      if (projectIndex !== -1) {
-        return { customerIndex, projectIndex }
-      }
-    }
-    return null
-  }
-
-  function locateWO(db: Customer[], woId: string): { customerIndex: number; projectIndex: number; woIndex: number } | null {
-    for (let customerIndex = 0; customerIndex < db.length; customerIndex += 1) {
-      const customer = db[customerIndex]
-      for (let projectIndex = 0; projectIndex < customer.projects.length; projectIndex += 1) {
-        const woIndex = customer.projects[projectIndex].wos.findIndex(wo => wo.id === woId)
-        if (woIndex !== -1) {
-          return { customerIndex, projectIndex, woIndex }
-        }
-      }
-    }
-    return null
-  }
-
-  function locatePO(db: Customer[], poId: string): { customerIndex: number; projectIndex: number; poIndex: number } | null {
-    for (let customerIndex = 0; customerIndex < db.length; customerIndex += 1) {
-      const customer = db[customerIndex]
-      for (let projectIndex = 0; projectIndex < customer.projects.length; projectIndex += 1) {
-        const poIndex = customer.projects[projectIndex].pos.findIndex(po => po.id === poId)
-        if (poIndex !== -1) {
-          return { customerIndex, projectIndex, poIndex }
-        }
-      }
-    }
-    return null
-  }
-
-  return {
-    async listCustomers(): Promise<Customer[]> {
-      const db = read()
-      return sortByText(db.map(cloneCustomer), customer => customer.name)
-    },
-
-    async listProjectsByCustomer(customerId: string): Promise<Project[]> {
-      const db = read()
-      const customer = db.find(c => c.id === customerId)
-      if (!customer) {
-        return []
-      }
-      return sortByText(customer.projects.map(cloneProject), project => project.number)
-    },
-
-    async listWOs(projectId: string): Promise<WO[]> {
-      const db = read()
-      const location = locateProject(db, projectId)
-      if (!location) {
-        return []
-      }
-      const project = db[location.customerIndex].projects[location.projectIndex]
-      return sortByText(project.wos.map(cloneWO), wo => wo.number)
-    },
-
-    async listPOs(projectId: string): Promise<PO[]> {
-      const db = read()
-      const location = locateProject(db, projectId)
-      if (!location) {
-        return []
-      }
-      const project = db[location.customerIndex].projects[location.projectIndex]
-      return sortByText(project.pos.map(clonePO), po => po.number)
-    },
-
-    async createCustomer(data: {
-      name: string
-      address?: string
-      contactName?: string
-      contactPhone?: string
-      contactEmail?: string
-    }): Promise<Customer> {
-      const db = read()
-      const customer: Customer = {
-        id: generateId('cust'),
-        name: data.name,
-        address: data.address ?? undefined,
-        contactName: data.contactName ?? undefined,
-        contactPhone: data.contactPhone ?? undefined,
-        contactEmail: data.contactEmail ?? undefined,
-        projects: [],
-      }
-      write([customer, ...db])
-      return cloneCustomer(customer)
-    },
-
-    async updateCustomer(
-      customerId: string,
-      data: {
-        name?: string
-        address?: string | null
-        contactName?: string | null
-        contactPhone?: string | null
-        contactEmail?: string | null
-      },
-    ): Promise<Customer> {
-      const db = read()
-      const index = db.findIndex(c => c.id === customerId)
-      if (index === -1) {
-        throw new Error('Customer not found.')
-      }
-      const current = db[index]
-      const updated: Customer = {
-        ...current,
-        name: data.name ?? current.name,
-        address: data.address === undefined ? current.address : data.address ?? undefined,
-        contactName: data.contactName === undefined ? current.contactName : data.contactName ?? undefined,
-        contactPhone: data.contactPhone === undefined ? current.contactPhone : data.contactPhone ?? undefined,
-        contactEmail: data.contactEmail === undefined ? current.contactEmail : data.contactEmail ?? undefined,
-      }
-      const next = [...db]
-      next[index] = updated
-      write(next)
-      return cloneCustomer(updated)
-    },
-
-    async deleteCustomer(customerId: string): Promise<void> {
-      const db = read()
-      const next = db.filter(c => c.id !== customerId)
-      if (next.length === db.length) {
-        return
-      }
-      write(next)
-    },
-
-    async createProject(customerId: string, number: string): Promise<Project> {
-      const db = read()
-      const index = db.findIndex(c => c.id === customerId)
-      if (index === -1) {
-        throw new Error('Customer not found.')
-      }
-      const project: Project = {
-        id: generateId('proj'),
-        number,
-        note: undefined,
-        wos: [],
-        pos: [],
-      }
-      const customer = db[index]
-      const updatedCustomer: Customer = {
-        ...customer,
-        projects: sortByText([...customer.projects, project], p => p.number),
-      }
-      const next = [...db]
-      next[index] = updatedCustomer
-      write(next)
-      return cloneProject(project)
-    },
-
-    async updateProject(projectId: string, data: { note?: string | null }): Promise<Project> {
-      const db = read()
-      const location = locateProject(db, projectId)
-      if (!location) {
-        throw new Error('Project not found.')
-      }
-      const customer = db[location.customerIndex]
-      const project = customer.projects[location.projectIndex]
-      const updatedProject: Project = {
-        ...project,
-        note: data.note === undefined ? project.note : data.note ?? undefined,
-      }
-      const updatedCustomer: Customer = {
-        ...customer,
-        projects: customer.projects.map((p, idx) => (idx === location.projectIndex ? updatedProject : p)),
-      }
-      const next = [...db]
-      next[location.customerIndex] = updatedCustomer
-      write(next)
-      return cloneProject(updatedProject)
-    },
-
-    async deleteProject(projectId: string): Promise<void> {
-      const db = read()
-      const location = locateProject(db, projectId)
-      if (!location) {
-        return
-      }
-      const customer = db[location.customerIndex]
-      const updatedCustomer: Customer = {
-        ...customer,
-        projects: customer.projects.filter(project => project.id !== projectId),
-      }
-      const next = [...db]
-      next[location.customerIndex] = updatedCustomer
-      write(next)
-    },
-
-    async createWO(projectId: string, data: { number: string; type: WOType; note?: string }): Promise<WO> {
-      const db = read()
-      const location = locateProject(db, projectId)
-      if (!location) {
-        throw new Error('Project not found.')
-      }
-      const customer = db[location.customerIndex]
-      const project = customer.projects[location.projectIndex]
-      const newWO: WO = {
-        id: generateId('wo'),
-        number: data.number,
-        type: data.type,
-        note: data.note && data.note.trim().length > 0 ? data.note : undefined,
-      }
-      const updatedProject: Project = {
-        ...project,
-        wos: sortByText([...project.wos, newWO], wo => wo.number),
-      }
-      const updatedCustomer: Customer = {
-        ...customer,
-        projects: customer.projects.map((p, idx) => (idx === location.projectIndex ? updatedProject : p)),
-      }
-      const next = [...db]
-      next[location.customerIndex] = updatedCustomer
-      write(next)
-      return cloneWO(newWO)
-    },
-
-    async deleteWO(woId: string): Promise<void> {
-      const db = read()
-      const location = locateWO(db, woId)
-      if (!location) {
-        return
-      }
-      const customer = db[location.customerIndex]
-      const project = customer.projects[location.projectIndex]
-      const updatedProject: Project = {
-        ...project,
-        wos: project.wos.filter((_, idx) => idx !== location.woIndex),
-      }
-      const updatedCustomer: Customer = {
-        ...customer,
-        projects: customer.projects.map((p, idx) => (idx === location.projectIndex ? updatedProject : p)),
-      }
-      const next = [...db]
-      next[location.customerIndex] = updatedCustomer
-      write(next)
-    },
-
-    async createPO(projectId: string, data: { number: string; note?: string }): Promise<PO> {
-      const db = read()
-      const location = locateProject(db, projectId)
-      if (!location) {
-        throw new Error('Project not found.')
-      }
-      const customer = db[location.customerIndex]
-      const project = customer.projects[location.projectIndex]
-      const newPO: PO = {
-        id: generateId('po'),
-        number: data.number,
-        note: data.note && data.note.trim().length > 0 ? data.note : undefined,
-      }
-      const updatedProject: Project = {
-        ...project,
-        pos: sortByText([...project.pos, newPO], po => po.number),
-      }
-      const updatedCustomer: Customer = {
-        ...customer,
-        projects: customer.projects.map((p, idx) => (idx === location.projectIndex ? updatedProject : p)),
-      }
-      const next = [...db]
-      next[location.customerIndex] = updatedCustomer
-      write(next)
-      return clonePO(newPO)
-    },
-
-    async deletePO(poId: string): Promise<void> {
-      const db = read()
-      const location = locatePO(db, poId)
-      if (!location) {
-        return
-      }
-      const customer = db[location.customerIndex]
-      const project = customer.projects[location.projectIndex]
-      const updatedProject: Project = {
-        ...project,
-        pos: project.pos.filter((_, idx) => idx !== location.poIndex),
-      }
-      const updatedCustomer: Customer = {
-        ...customer,
-        projects: customer.projects.map((p, idx) => (idx === location.projectIndex ? updatedProject : p)),
-      }
-      const next = [...db]
-      next[location.customerIndex] = updatedCustomer
-      write(next)
     },
   }
 }

--- a/src/lib/supabaseErrors.ts
+++ b/src/lib/supabaseErrors.ts
@@ -1,0 +1,82 @@
+const NETWORK_ERROR_PATTERNS = [
+  'fetch failed',
+  'failed to fetch',
+  'network request failed',
+  'network error',
+  'getaddrinfo',
+  'enotfound',
+  'etimedout',
+  'econnreset',
+  'econnrefused',
+  'ehostunreachable',
+  'ssl connect error',
+  'certificate',
+  'temporarily unreachable',
+  'edge function',
+  'functionsfetcherror',
+]
+
+const EDGE_FUNCTION_PATTERNS = ['edge function', 'functionsfetcherror']
+
+type WithMessage = { message?: unknown; name?: unknown }
+
+export function extractSupabaseErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message || ''
+  }
+
+  if (typeof error === 'string') {
+    return error
+  }
+
+  if (error && typeof error === 'object') {
+    const withMessage = error as WithMessage
+    if (typeof withMessage.message === 'string') {
+      return withMessage.message
+    }
+  }
+
+  return ''
+}
+
+function getErrorName(error: unknown): string {
+  if (error instanceof Error && typeof error.name === 'string') {
+    return error.name
+  }
+
+  if (error && typeof error === 'object' && typeof (error as WithMessage).name === 'string') {
+    return String((error as WithMessage).name)
+  }
+
+  return ''
+}
+
+export function isSupabaseUnavailableError(error: unknown): boolean {
+  const message = extractSupabaseErrorMessage(error).toLowerCase()
+  const name = getErrorName(error).toLowerCase()
+
+  if (name && NETWORK_ERROR_PATTERNS.some(pattern => name.includes(pattern))) {
+    return true
+  }
+
+  if (!message) {
+    return false
+  }
+
+  return NETWORK_ERROR_PATTERNS.some(pattern => message.includes(pattern))
+}
+
+export function isSupabaseEdgeFunctionUnavailable(error: unknown): boolean {
+  const message = extractSupabaseErrorMessage(error).toLowerCase()
+  const name = getErrorName(error).toLowerCase()
+
+  if (EDGE_FUNCTION_PATTERNS.some(pattern => name.includes(pattern))) {
+    return true
+  }
+
+  if (!message) {
+    return false
+  }
+
+  return EDGE_FUNCTION_PATTERNS.some(pattern => message.includes(pattern))
+}


### PR DESCRIPTION
## Summary
- remove the browser storage fallback so all persistence flows through Supabase with improved error translation for network and RLS issues
- update the app to operate in Supabase-only mode, surfacing configuration guidance and defaulting new accounts to full access when no roles are returned

## Testing
- npm run build *(fails: sh: 1: vite: Permission denied)*
- npx tsc -b

------
https://chatgpt.com/codex/tasks/task_e_68d1459af9248321a10146813a8c7966