### PR TITLE
Refine Supabase edge function error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "sh -c \"node --loader ./ts-test-loader.mjs --test $(find tests -name '*.test.ts' -print | tr '\\n' ' ')\""
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.57.4",

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,9 +1,25 @@
 // src/lib/supabase.ts
 import { createClient } from '@supabase/supabase-js'
 
-const url = import.meta.env.VITE_SUPABASE_URL
-const anon = import.meta.env.VITE_SUPABASE_ANON_KEY
+type SupabaseEnv = {
+  VITE_SUPABASE_URL?: string
+  VITE_SUPABASE_ANON_KEY?: string
+}
 
-export const supabase = (url && anon)
-  ? createClient(url, anon)
-  : null
+const env = (typeof import.meta !== 'undefined' && (import.meta as { env?: SupabaseEnv }).env) ?? {}
+const url = env?.VITE_SUPABASE_URL
+const anon = env?.VITE_SUPABASE_ANON_KEY
+
+export const supabase = url && anon ? createClient(url, anon) : null
+
+export function isSupabaseConfigured(): boolean {
+  return !!supabase
+}
+
+export function getSupabaseClient() {
+  if (!supabase) {
+    throw new Error('Supabase is not configured.')
+  }
+
+  return supabase
+}

--- a/src/lib/supabaseErrors.ts
+++ b/src/lib/supabaseErrors.ts
@@ -12,11 +12,10 @@ const NETWORK_ERROR_PATTERNS = [
   'ssl connect error',
   'certificate',
   'temporarily unreachable',
-  'edge function',
   'functionsfetcherror',
 ]
 
-const EDGE_FUNCTION_PATTERNS = ['edge function', 'functionsfetcherror']
+const EDGE_FUNCTION_FETCH_ERROR_NAME = 'functionsfetcherror'
 
 type WithMessage = { message?: unknown; name?: unknown }
 
@@ -67,16 +66,17 @@ export function isSupabaseUnavailableError(error: unknown): boolean {
 }
 
 export function isSupabaseEdgeFunctionUnavailable(error: unknown): boolean {
-  const message = extractSupabaseErrorMessage(error).toLowerCase()
   const name = getErrorName(error).toLowerCase()
 
-  if (EDGE_FUNCTION_PATTERNS.some(pattern => name.includes(pattern))) {
-    return true
-  }
-
-  if (!message) {
+  if (name !== EDGE_FUNCTION_FETCH_ERROR_NAME) {
     return false
   }
 
-  return EDGE_FUNCTION_PATTERNS.some(pattern => message.includes(pattern))
+  const message = extractSupabaseErrorMessage(error).toLowerCase()
+
+  if (!message) {
+    return true
+  }
+
+  return NETWORK_ERROR_PATTERNS.some(pattern => message.includes(pattern))
 }

--- a/tests/roles.test.ts
+++ b/tests/roles.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { Session } from '@supabase/supabase-js'
+
+import {
+  __resetSupabaseClientGetterForTesting,
+  __setSupabaseClientGetterForTesting,
+  fetchManagedUsers,
+  updateUserRole,
+} from '../src/lib/roles.ts'
+
+function createSession(): Session {
+  return { access_token: 'token' } as Session
+}
+
+test('fetchManagedUsers surfaces HTTP failures from the edge function', async t => {
+  __setSupabaseClientGetterForTesting(() => ({
+    functions: {
+      invoke: async () => ({
+        data: null,
+        error: { message: 'Function invocation failed with status 500', name: 'FunctionsHttpError' },
+      }),
+    },
+  }))
+  t.after(__resetSupabaseClientGetterForTesting)
+
+  await assert.rejects(async () => fetchManagedUsers(createSession()), error => {
+    assert.equal((error as Error).message, 'Function invocation failed with status 500')
+    return true
+  })
+})
+
+test('fetchManagedUsers reports connectivity issues with the fallback message', async t => {
+  __setSupabaseClientGetterForTesting(() => ({
+    functions: {
+      invoke: async () => ({
+        data: null,
+        error: { message: 'Fetch failed because the server could not be reached', name: 'FunctionsFetchError' },
+      }),
+    },
+  }))
+  t.after(__resetSupabaseClientGetterForTesting)
+
+  await assert.rejects(async () => fetchManagedUsers(createSession()), error => {
+    assert.equal(
+      (error as Error).message,
+      'Unable to reach the Supabase user-management function. Confirm it is deployed and that your network can access it.',
+    )
+    return true
+  })
+})
+
+test('updateUserRole surfaces HTTP failures from the edge function', async t => {
+  __setSupabaseClientGetterForTesting(() => ({
+    functions: {
+      invoke: async () => ({
+        data: null,
+        error: { message: 'Update failed due to validation error', name: 'FunctionsHttpError' },
+      }),
+    },
+  }))
+  t.after(__resetSupabaseClientGetterForTesting)
+
+  await assert.rejects(
+    async () => updateUserRole(createSession(), { action: 'grant', email: 'user@example.com', role: 'admin' }),
+    error => {
+      assert.equal((error as Error).message, 'Update failed due to validation error')
+      return true
+    },
+  )
+})
+
+test('updateUserRole reports connectivity issues with the fallback message', async t => {
+  __setSupabaseClientGetterForTesting(() => ({
+    functions: {
+      invoke: async () => ({
+        data: null,
+        error: { message: 'Fetch failed because the server could not be reached', name: 'FunctionsFetchError' },
+      }),
+    },
+  }))
+  t.after(__resetSupabaseClientGetterForTesting)
+
+  await assert.rejects(
+    async () => updateUserRole(createSession(), { action: 'grant', email: 'user@example.com', role: 'admin' }),
+    error => {
+      assert.equal(
+        (error as Error).message,
+        'Unable to reach the Supabase user-management function. Confirm it is deployed and that your network can access it.',
+      )
+      return true
+    },
+  )
+})

--- a/tests/supabaseErrors.test.ts
+++ b/tests/supabaseErrors.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isSupabaseEdgeFunctionUnavailable } from '../src/lib/supabaseErrors.ts'
+
+test('identifies FunctionsFetchError connectivity failures', () => {
+  const error = new Error('Fetch failed because the server could not be reached')
+  error.name = 'FunctionsFetchError'
+
+  assert.equal(isSupabaseEdgeFunctionUnavailable(error), true)
+})
+
+test('does not treat HTTP failures as connectivity issues', () => {
+  const error = new Error('Function invocation failed with status 500')
+  error.name = 'FunctionsHttpError'
+
+  assert.equal(isSupabaseEdgeFunctionUnavailable(error), false)
+})

--- a/ts-test-loader.mjs
+++ b/ts-test-loader.mjs
@@ -1,0 +1,65 @@
+import { access, readFile } from 'node:fs/promises'
+import { dirname, resolve as pathResolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import ts from 'typescript'
+
+const TS_EXTENSIONS = ['.ts', '.tsx']
+
+function isRelative(specifier) {
+  return specifier.startsWith('./') || specifier.startsWith('../')
+}
+
+function resolveToPath(specifier, parentURL) {
+  if (specifier.startsWith('file://')) {
+    return fileURLToPath(specifier)
+  }
+
+  if (parentURL) {
+    const parentPath = fileURLToPath(parentURL)
+    return pathResolve(dirname(parentPath), specifier)
+  }
+
+  return pathResolve(specifier)
+}
+
+export async function resolve(specifier, context, defaultResolve) {
+  if (TS_EXTENSIONS.some(ext => specifier.endsWith(ext))) {
+    const resolvedPath = resolveToPath(specifier, context.parentURL)
+    return { url: pathToFileURL(resolvedPath).href, shortCircuit: true }
+  }
+
+  if (isRelative(specifier) && context.parentURL) {
+    for (const ext of TS_EXTENSIONS) {
+      const candidatePath = resolveToPath(specifier + ext, context.parentURL)
+      try {
+        await access(candidatePath)
+        return { url: pathToFileURL(candidatePath).href, shortCircuit: true }
+      } catch {
+        // continue searching
+      }
+    }
+  }
+
+  return defaultResolve(specifier, context, defaultResolve)
+}
+
+export async function load(url, context, defaultLoad) {
+  if (TS_EXTENSIONS.some(ext => url.endsWith(ext))) {
+    const source = await readFile(new URL(url), 'utf8')
+    const transformed = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext,
+        target: ts.ScriptTarget.ES2020,
+        jsx: ts.JsxEmit.ReactJSX,
+        esModuleInterop: true,
+        sourceMap: false,
+      },
+      fileName: fileURLToPath(url),
+    })
+
+    return { format: 'module', source: transformed.outputText, shortCircuit: true }
+  }
+
+  return defaultLoad(url, context, defaultLoad)
+}

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": ".",
+    "outDir": "build/tests",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "allowJs": false,
+    "allowImportingTsExtensions": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "types": ["node", "vite/client"],
+    "noEmit": false
+  },
+  "include": ["src/lib/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- restrict Supabase edge-function connectivity detection to genuine `FunctionsFetchError` cases
- make the roles helpers use an overridable Supabase client so HTTP errors surface their real messages
- add node-based tests and loader coverage for the revised Supabase error handling

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d166c8d8e083219e1348512f21529b