### PR TITLE
Remove purchase orders and add FDS upload support

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,11 @@ export type WO = {
   note?: string;
 };
 
-export type PO = {
-  id: string;
-  number: string;
-  note?: string;
+export type ProjectFDS = {
+  name: string;
+  type: string;
+  dataUrl: string;
+  uploadedAt: string;
 };
 
 export type Project = {
@@ -18,7 +19,7 @@ export type Project = {
   number: string;
   note?: string; // ⬅️ new
   wos: WO[];
-  pos: PO[];
+  fds?: ProjectFDS;
 };
 
 export type Customer = {


### PR DESCRIPTION
## Summary
- replace purchase order data structures with a new ProjectFDS type that tracks document metadata
- persist optional FDS details in local storage and expose upload/removal handlers from the app
- refresh the project UI to remove purchase orders, show FDS status in summaries, and provide preview/upload/download controls

## Testing
- npm run build *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68d28381f3288321bc8b97196d5783eb