### PR TITLE
Add project document management and multi-contact support

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,28 +7,40 @@ export type WO = {
   note?: string;
 };
 
-export type ProjectFDS = {
+export type ProjectFileCategory = 'fds' | 'electrical' | 'mechanical';
+
+export const PROJECT_FILE_CATEGORIES: ProjectFileCategory[] = ['fds', 'electrical', 'mechanical'];
+
+export type ProjectFile = {
   name: string;
   type: string;
   dataUrl: string;
   uploadedAt: string;
 };
 
+export type ProjectDocuments = Partial<Record<ProjectFileCategory, ProjectFile>>;
+
 export type Project = {
   id: string;
   number: string;
   note?: string; // ⬅️ new
   wos: WO[];
-  fds?: ProjectFDS;
+  documents?: ProjectDocuments;
+};
+
+export type CustomerContact = {
+  id: string;
+  name?: string;
+  position?: string;
+  phone?: string;
+  email?: string;
 };
 
 export type Customer = {
   id: string;
   name: string;
   address?: string;
-  contactName?: string;
-  contactPhone?: string;
-  contactEmail?: string;
+  contacts: CustomerContact[];
   projects: Project[];
 };
 


### PR DESCRIPTION
## Summary
- allow projects to manage FDS, electrical, and mechanical documents with previews in a collapsible section
- refactor customer contacts to support multiple entries with position information and inline editing
- update storage layer and UI copy helpers to work with new document/contacts data structures

## Testing
- npm run build *(fails: rollup optional binary @rollup/rollup-linux-x64-gnu unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d28d0858d883218e5e6ce7feb8296d