### PR TITLE
feat: add project status tracking

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,18 @@ export type ProjectFileCategory = 'fds' | 'electrical' | 'mechanical';
 
 export const PROJECT_FILE_CATEGORIES: ProjectFileCategory[] = ['fds', 'electrical', 'mechanical'];
 
+export const PROJECT_STATUS_OPTIONS = ['Active', 'Complete'] as const;
+
+export type ProjectStatus = (typeof PROJECT_STATUS_OPTIONS)[number];
+
+export const PROJECT_ACTIVE_SUB_STATUS_OPTIONS = ['FDS', 'Design', 'Build', 'Install'] as const;
+
+export type ProjectActiveSubStatus = (typeof PROJECT_ACTIVE_SUB_STATUS_OPTIONS)[number];
+
+export const DEFAULT_PROJECT_STATUS: ProjectStatus = 'Active';
+
+export const DEFAULT_PROJECT_ACTIVE_SUB_STATUS: ProjectActiveSubStatus = 'FDS';
+
 export type ProjectFile = {
   name: string;
   type: string;
@@ -23,6 +35,8 @@ export type ProjectDocuments = Partial<Record<ProjectFileCategory, ProjectFile>>
 export type Project = {
   id: string;
   number: string;
+  status: ProjectStatus;
+  activeSubStatus?: ProjectActiveSubStatus;
   note?: string; // ⬅️ new
   wos: WO[];
   documents?: ProjectDocuments;
@@ -45,3 +59,9 @@ export type Customer = {
 };
 
 export type AppRole = 'viewer' | 'editor' | 'admin';
+
+export function formatProjectStatus(status: ProjectStatus, activeSubStatus?: ProjectActiveSubStatus): string {
+  return status === 'Active'
+    ? `Active — ${activeSubStatus ?? DEFAULT_PROJECT_ACTIVE_SUB_STATUS}`
+    : 'Complete';
+}


### PR DESCRIPTION
## Summary
- add Active/Complete project status types and persist them in storage
- expose project status management on the project detail page and surface the current stage in summaries
- replace the home dashboard sub-status metrics with lifecycle status buckets

## Testing
- npx tsc -b
- npm run build *(fails: vite binary lacks execute bit and rollup optional dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b3b1d9108321925e32c6e55b93e5