### PR TITLE
Improve sidebar layout and project workflows

### DIFF
--- a/src/components/ui/PieChart.tsx
+++ b/src/components/ui/PieChart.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react'
+
+interface PieChartDatum {
+  value: number
+  color: string
+}
+
+interface PieChartProps {
+  data: PieChartDatum[]
+  size?: number
+  thickness?: number
+  trackColor?: string
+  className?: string
+  centerContent?: ReactNode
+  ariaLabel?: string
+}
+
+export default function PieChart({
+  data,
+  size = 192,
+  thickness = 52,
+  trackColor = '#e2e8f0',
+  className,
+  centerContent,
+  ariaLabel,
+}: PieChartProps) {
+  const total = data.reduce((sum, item) => (item.value > 0 ? sum + item.value : sum), 0)
+  let gradientSegments: string[] = []
+
+  if (total > 0) {
+    let cumulative = 0
+    gradientSegments = data
+      .filter(item => item.value > 0)
+      .map(item => {
+        const start = (cumulative / total) * 360
+        cumulative += item.value
+        const end = (cumulative / total) * 360
+        return `${item.color} ${start}deg ${end}deg`
+      })
+  }
+
+  const gradientBackground =
+    gradientSegments.length > 0 ? `conic-gradient(${gradientSegments.join(', ')})` : trackColor
+
+  const innerSize = Math.max(size - thickness, 0)
+  const containerClass = ['relative flex items-center justify-center', className]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div
+      className={containerClass}
+      style={{ width: size, height: size }}
+      role={ariaLabel ? 'img' : undefined}
+      aria-label={ariaLabel}
+    >
+      <div
+        className='absolute inset-0 rounded-full border border-white/40 shadow-inner'
+        style={{ background: gradientBackground }}
+        aria-hidden
+      />
+      <div
+        className='relative flex items-center justify-center rounded-full bg-white text-center shadow'
+        style={{ width: innerSize, height: innerSize }}
+        aria-hidden
+      >
+        {centerContent}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- keep the primary navigation sidebar docked on the left at all viewport widths
- streamline the customer and project index cards into denser list-style entries and introduce a modal workflow for creating projects
- replace the dashboard status bars with a reusable pie chart visualization for project stages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d3b2722ba48321ae0df0cafb29b034