### PR TITLE
Revise customer overview layout with streamlined actions

### DIFF
--- a/src/app/ProjectPage.tsx
+++ b/src/app/ProjectPage.tsx
@@ -329,6 +329,7 @@ export default function ProjectPage({
             title='Copy project number'
           >
             <Copy size={16} />
+            <span className='sr-only'>Copy project number</span>
           </Button>
           <Button
             variant='ghost'
@@ -427,6 +428,7 @@ export default function ProjectPage({
                       title='Copy work order'
                     >
                       <Copy size={16} />
+                      <span className='sr-only'>Copy work order number</span>
                     </Button>
                     <Button
                       variant='ghost'


### PR DESCRIPTION
## Summary
- move customer edit/delete actions to icon-only buttons aligned to the right and allow detail fields to wrap without overflow
- embed a Google Maps preview alongside the address and convert copy/edit affordances to icon buttons with accessible labels across the app
- simplify project cards to show status and note inline while removing ancillary counters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3bf59d0dc8321bcb1075db4f6522d