### PR TITLE
Implement customer sign-off workflow and UI updates

### DIFF
--- a/src/app/ProjectPage.tsx
+++ b/src/app/ProjectPage.tsx
@@ -1,15 +1,15 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import type { ChangeEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { ChangeEvent, PointerEvent as ReactPointerEvent } from 'react'
 import {
   AlertCircle,
   ArrowLeft,
-  CheckCircle2,
   ChevronDown,
+  ChevronRight,
   Clock,
   Copy,
   Download,
   FileText,
-  List,
+  Pencil,
   Plus,
   Trash2,
   Upload,
@@ -19,10 +19,13 @@ import type {
   Customer,
   Project,
   ProjectActiveSubStatus,
+  ProjectCustomerSignOff,
   ProjectFile,
   ProjectFileCategory,
   ProjectStatus,
   WOType,
+  CustomerSignOffDecision,
+  CustomerSignOffSubmission,
 } from '../types'
 import {
   DEFAULT_PROJECT_ACTIVE_SUB_STATUS,
@@ -34,6 +37,7 @@ import Button from '../components/ui/Button'
 import Input from '../components/ui/Input'
 import Label from '../components/ui/Label'
 import { Card, CardContent, CardHeader } from '../components/ui/Card'
+import { CUSTOMER_SIGN_OFF_OPTIONS, CUSTOMER_SIGN_OFF_OPTION_COPY } from '../lib/signOff'
 
 export type ProjectPageProps = {
   customer: Customer
@@ -50,8 +54,9 @@ export type ProjectPageProps = {
   onDeleteWO: (woId: string) => void
   onUploadDocument: (category: ProjectFileCategory, file: File) => Promise<string | null>
   onRemoveDocument: (category: ProjectFileCategory, fileId: string) => Promise<string | null>
-  onAddSignOff: (data: { category: ProjectFileCategory; signedBy: string; note?: string }) => Promise<string | null>
-  onRemoveSignOff: (signOffId: string) => Promise<string | null>
+  onUploadCustomerSignOff: (file: File) => Promise<string | null>
+  onGenerateCustomerSignOff: (submission: CustomerSignOffSubmission) => Promise<string | null>
+  onRemoveCustomerSignOff: () => Promise<string | null>
   onDeleteProject: () => void
   onNavigateBack: () => void
   onReturnToIndex: () => void
@@ -87,6 +92,53 @@ function stripPrefix(value: string, pattern: RegExp): string {
   const match = trimmed.match(pattern)
   return match ? match[1].trim() : trimmed
 }
+
+const ACTIVE_STATUS_STYLES: Record<
+  ProjectActiveSubStatus,
+  { selectClass: string; indicatorClass: string }
+> = {
+  FDS: {
+    selectClass: 'bg-indigo-50 text-indigo-900 border-indigo-200',
+    indicatorClass: 'bg-indigo-500',
+  },
+  Design: {
+    selectClass: 'bg-sky-50 text-sky-900 border-sky-200',
+    indicatorClass: 'bg-sky-500',
+  },
+  Build: {
+    selectClass: 'bg-emerald-50 text-emerald-900 border-emerald-200',
+    indicatorClass: 'bg-emerald-500',
+  },
+  Install: {
+    selectClass: 'bg-amber-50 text-amber-900 border-amber-200',
+    indicatorClass: 'bg-amber-500',
+  },
+}
+
+const STATUS_SELECTIONS: Array<{
+  key: string
+  status: ProjectStatus
+  activeSubStatus?: ProjectActiveSubStatus
+  label: string
+  selectClass: string
+  indicatorClass: string
+}> = [
+  ...PROJECT_ACTIVE_SUB_STATUS_OPTIONS.map(stage => ({
+    key: `Active:${stage}`,
+    status: 'Active' as ProjectStatus,
+    activeSubStatus: stage,
+    label: `Active — ${stage}`,
+    selectClass: ACTIVE_STATUS_STYLES[stage].selectClass,
+    indicatorClass: ACTIVE_STATUS_STYLES[stage].indicatorClass,
+  })),
+  {
+    key: 'Complete',
+    status: 'Complete' as ProjectStatus,
+    label: 'Complete',
+    selectClass: 'bg-slate-200 text-slate-800 border-slate-300',
+    indicatorClass: 'bg-slate-500',
+  },
+]
 
 function isPdfDocument(file?: ProjectFile): boolean {
   if (!file) {
@@ -134,8 +186,9 @@ export default function ProjectPage({
   onDeleteWO,
   onUploadDocument,
   onRemoveDocument,
-  onAddSignOff,
-  onRemoveSignOff,
+  onUploadCustomerSignOff,
+  onGenerateCustomerSignOff,
+  onRemoveCustomerSignOff,
   onDeleteProject,
   onNavigateBack,
   onReturnToIndex,
@@ -145,6 +198,7 @@ export default function ProjectPage({
     project.activeSubStatus ?? DEFAULT_PROJECT_ACTIVE_SUB_STATUS,
   )
   const [noteDraft, setNoteDraft] = useState(project.note ?? '')
+  const [isEditingNote, setIsEditingNote] = useState(false)
   const [activeTab, setActiveTab] = useState<ProjectTab>('files')
   const [woForm, setWoForm] = useState({ number: '', type: 'Build' as WOType, note: '' })
   const [woError, setWoError] = useState<string | null>(null)
@@ -157,20 +211,34 @@ export default function ProjectPage({
   const [uploadingCategory, setUploadingCategory] = useState<ProjectFileCategory | null>(null)
   const [removingFile, setRemovingFile] = useState<{ category: ProjectFileCategory; fileId: string } | null>(null)
   const [expandedPreviews, setExpandedPreviews] = useState<Set<string>>(() => new Set())
-  const [signOffForm, setSignOffForm] = useState({
-    category: PROJECT_FILE_CATEGORIES[0],
-    signedBy: currentUser,
-    note: '',
-  })
-  const [isSavingSignOff, setIsSavingSignOff] = useState(false)
+  const [isUploadingSignOff, setIsUploadingSignOff] = useState(false)
+  const [isRemovingSignOff, setIsRemovingSignOff] = useState(false)
+  const [isGeneratingSignOff, setIsGeneratingSignOff] = useState(false)
+  const [isCompletingSignOff, setIsCompletingSignOff] = useState(false)
   const [signOffError, setSignOffError] = useState<string | null>(null)
-  const [removingSignOffId, setRemovingSignOffId] = useState<string | null>(null)
+  const [signOffDraft, setSignOffDraft] = useState<{
+    name: string
+    position: string
+    decision: CustomerSignOffDecision
+    snagsText: string
+  }>({
+    name: '',
+    position: '',
+    decision: 'option1',
+    snagsText: '',
+  })
+  const [hasSignature, setHasSignature] = useState(false)
   const [showStatusHistory, setShowStatusHistory] = useState(false)
   const fileInputRefs = useRef<Record<ProjectFileCategory, HTMLInputElement | null>>({
     fds: null,
     electrical: null,
     mechanical: null,
   })
+  const uploadSignOffInputRef = useRef<HTMLInputElement | null>(null)
+  const signatureCanvasRef = useRef<HTMLCanvasElement | null>(null)
+  const signatureDrawingRef = useRef(false)
+  const signatureStrokesRef = useRef<Array<Array<{ x: number; y: number }>>>([])
+  const activeSignatureStrokeRef = useRef<number | null>(null)
 
   const documents = project.documents ?? {}
   const documentsCount = useMemo(
@@ -188,12 +256,32 @@ export default function ProjectPage({
     )
   }, [project.statusHistory])
   const latestStatusEntry = statusHistory[0] ?? null
-  const signOffs = project.signOffs ?? []
+  const customerSignOff = project.customerSignOff ?? null
+  const statusSelectionValue =
+    statusDraft === 'Active' ? `Active:${activeSubStatusDraft}` : 'Complete'
+  const statusSelectionOption = STATUS_SELECTIONS.find(option => option.key === statusSelectionValue)
+
+  const resetSignature = useCallback(() => {
+    const canvas = signatureCanvasRef.current
+    if (!canvas) {
+      return
+    }
+    const context = canvas.getContext('2d')
+    if (!context) {
+      return
+    }
+    context.clearRect(0, 0, canvas.width, canvas.height)
+    signatureDrawingRef.current = false
+    activeSignatureStrokeRef.current = null
+    signatureStrokesRef.current = []
+    setHasSignature(false)
+  }, [])
 
   useEffect(() => {
     setStatusDraft(project.status)
     setActiveSubStatusDraft(project.activeSubStatus ?? DEFAULT_PROJECT_ACTIVE_SUB_STATUS)
     setNoteDraft(project.note ?? '')
+    setIsEditingNote(false)
     setWoForm({ number: '', type: 'Build', note: '' })
     setWoError(null)
     setFileErrors({ fds: null, electrical: null, mechanical: null })
@@ -201,19 +289,21 @@ export default function ProjectPage({
     setRemovingFile(null)
     setExpandedPreviews(new Set())
     setActiveTab('files')
-    setSignOffForm({ category: PROJECT_FILE_CATEGORIES[0], signedBy: currentUser, note: '' })
-    setIsSavingSignOff(false)
+    setIsUploadingSignOff(false)
+    setIsRemovingSignOff(false)
+    setIsGeneratingSignOff(false)
+    setIsCompletingSignOff(false)
     setSignOffError(null)
-    setRemovingSignOffId(null)
+    setSignOffDraft({ name: '', position: '', decision: 'option1', snagsText: '' })
+    resetSignature()
     setShowStatusHistory(false)
-  }, [project.id, currentUser])
+  }, [project.id, resetSignature])
 
   useEffect(() => {
-    setNoteDraft(prev => {
-      const next = project.note ?? ''
-      return prev === next ? prev : next
-    })
-  }, [project.note])
+    if (!isEditingNote) {
+      setNoteDraft(project.note ?? '')
+    }
+  }, [project.note, isEditingNote])
 
   useEffect(() => {
     setStatusDraft(project.status)
@@ -224,6 +314,31 @@ export default function ProjectPage({
       setActiveSubStatusDraft(project.activeSubStatus ?? DEFAULT_PROJECT_ACTIVE_SUB_STATUS)
     }
   }, [project.status, project.activeSubStatus])
+
+  useEffect(() => {
+    if (!isGeneratingSignOff) {
+      return
+    }
+    const canvas = signatureCanvasRef.current
+    if (!canvas) {
+      return
+    }
+    const context = canvas.getContext('2d')
+    if (!context) {
+      return
+    }
+    const ratio = window.devicePixelRatio || 1
+    const rect = canvas.getBoundingClientRect()
+    canvas.width = rect.width * ratio
+    canvas.height = rect.height * ratio
+    context.scale(ratio, ratio)
+    context.lineCap = 'round'
+    context.lineJoin = 'round'
+    context.lineWidth = 2
+    context.strokeStyle = '#111827'
+    signatureDrawingRef.current = false
+    context.beginPath()
+  }, [isGeneratingSignOff])
 
   const updateFileError = (category: ProjectFileCategory, message: string | null) => {
     setFileErrors(prev => ({ ...prev, [category]: message }))
@@ -241,15 +356,25 @@ export default function ProjectPage({
     })
   }
 
-  const handleStatusChange = (nextStatus: ProjectStatus) => {
-    setStatusDraft(nextStatus)
+  const handleStatusSelectionChange = (value: string) => {
+    const selection = STATUS_SELECTIONS.find(option => option.key === value)
+    if (!selection) {
+      return
+    }
+
+    setStatusDraft(selection.status)
+    if (selection.status === 'Active') {
+      setActiveSubStatusDraft(selection.activeSubStatus ?? DEFAULT_PROJECT_ACTIVE_SUB_STATUS)
+    }
+
     if (!canEdit) {
       return
     }
-    if (nextStatus === project.status) {
-      if (nextStatus === 'Active') {
+
+    if (selection.status === project.status) {
+      if (selection.status === 'Active') {
         const currentStage = project.activeSubStatus ?? DEFAULT_PROJECT_ACTIVE_SUB_STATUS
-        if (currentStage === activeSubStatusDraft) {
+        if (currentStage === (selection.activeSubStatus ?? currentStage)) {
           return
         }
       } else {
@@ -257,23 +382,227 @@ export default function ProjectPage({
       }
     }
 
-    if (nextStatus === 'Active') {
-      onUpdateProjectStatus('Active', activeSubStatusDraft, { changedBy: currentUser })
-    } else {
-      onUpdateProjectStatus('Complete', undefined, { changedBy: currentUser })
+    onUpdateProjectStatus(
+      selection.status,
+      selection.status === 'Active'
+        ? selection.activeSubStatus ?? DEFAULT_PROJECT_ACTIVE_SUB_STATUS
+        : undefined,
+      { changedBy: currentUser },
+    )
+  }
+
+  const handleSignOffFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) {
+      return
+    }
+
+    setIsUploadingSignOff(true)
+    setSignOffError(null)
+    try {
+      const result = await onUploadCustomerSignOff(file)
+      if (result) {
+        setSignOffError(result)
+      }
+    } finally {
+      setIsUploadingSignOff(false)
     }
   }
 
-  const handleActiveSubStatusChange = (nextStage: ProjectActiveSubStatus) => {
-    setActiveSubStatusDraft(nextStage)
+  const startGeneratingSignOff = () => {
     if (!canEdit) {
+      setSignOffError('You have read-only access.')
       return
     }
-    const currentStage = project.activeSubStatus ?? DEFAULT_PROJECT_ACTIVE_SUB_STATUS
-    if (project.status === 'Active' && currentStage === nextStage) {
+    setSignOffDraft({ name: '', position: '', decision: 'option1', snagsText: '' })
+    resetSignature()
+    setSignOffError(null)
+    setIsGeneratingSignOff(true)
+    setHasSignature(false)
+  }
+
+  const cancelGeneratingSignOff = () => {
+    setIsGeneratingSignOff(false)
+    setIsCompletingSignOff(false)
+    setSignOffDraft({ name: '', position: '', decision: 'option1', snagsText: '' })
+    resetSignature()
+    setSignOffError(null)
+  }
+
+  const handleRemoveCustomerSignOff = async () => {
+    if (!canEdit) {
+      setSignOffError('You have read-only access.')
       return
     }
-    onUpdateProjectStatus('Active', nextStage, { changedBy: currentUser })
+    const confirmed = window.confirm('Remove the existing customer sign off?')
+    if (!confirmed) {
+      return
+    }
+    setIsRemovingSignOff(true)
+    setSignOffError(null)
+    try {
+      const result = await onRemoveCustomerSignOff()
+      if (result) {
+        setSignOffError(result)
+      }
+    } finally {
+      setIsRemovingSignOff(false)
+    }
+  }
+
+  const getSignaturePoint = (
+    canvas: HTMLCanvasElement,
+    event: ReactPointerEvent<HTMLCanvasElement>,
+  ) => {
+    const rect = canvas.getBoundingClientRect()
+    const scaleX = canvas.width / rect.width
+    const scaleY = canvas.height / rect.height
+    return {
+      x: (event.clientX - rect.left) * scaleX,
+      y: (event.clientY - rect.top) * scaleY,
+    }
+  }
+
+  const handleSignaturePointerDown = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (!canEdit || !isGeneratingSignOff) {
+      return
+    }
+    const canvas = signatureCanvasRef.current
+    if (!canvas) {
+      return
+    }
+    const context = canvas.getContext('2d')
+    if (!context) {
+      return
+    }
+    event.preventDefault()
+    const point = getSignaturePoint(canvas, event)
+    context.beginPath()
+    context.moveTo(point.x, point.y)
+    signatureDrawingRef.current = true
+    const strokeIndex = signatureStrokesRef.current.length
+    signatureStrokesRef.current.push([point])
+    activeSignatureStrokeRef.current = strokeIndex
+    event.currentTarget.setPointerCapture(event.pointerId)
+  }
+
+  const handleSignaturePointerMove = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (!signatureDrawingRef.current) {
+      return
+    }
+    const canvas = signatureCanvasRef.current
+    if (!canvas) {
+      return
+    }
+    const context = canvas.getContext('2d')
+    if (!context) {
+      return
+    }
+    event.preventDefault()
+    const point = getSignaturePoint(canvas, event)
+    const activeIndex = activeSignatureStrokeRef.current
+    if (activeIndex !== null && signatureStrokesRef.current[activeIndex]) {
+      signatureStrokesRef.current[activeIndex].push(point)
+    }
+    context.lineTo(point.x, point.y)
+    context.stroke()
+    setHasSignature(true)
+  }
+
+  const finishSignatureStroke = (event?: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (signatureDrawingRef.current && event) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    signatureDrawingRef.current = false
+    activeSignatureStrokeRef.current = null
+    const canvas = signatureCanvasRef.current
+    const context = canvas?.getContext('2d')
+    context?.beginPath()
+  }
+
+  const handleSignaturePointerUp = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+    finishSignatureStroke(event)
+  }
+
+  const handleSignaturePointerLeave = () => {
+    finishSignatureStroke()
+  }
+
+  const handleCompleteSignOff = async () => {
+    if (!canEdit) {
+      setSignOffError('You have read-only access.')
+      return
+    }
+    const name = signOffDraft.name.trim()
+    const position = signOffDraft.position.trim()
+    if (!name) {
+      setSignOffError('Enter the signee name.')
+      return
+    }
+    if (!position) {
+      setSignOffError('Enter the signee position.')
+      return
+    }
+    if (!hasSignature) {
+      setSignOffError('Capture a signature to continue.')
+      return
+    }
+    const canvas = signatureCanvasRef.current
+    if (!canvas) {
+      setSignOffError('Signature pad not ready.')
+      return
+    }
+    const usableStrokes = signatureStrokesRef.current
+      .map(stroke => stroke.map(point => ({ x: point.x, y: point.y })))
+      .filter(stroke => stroke.length >= 2)
+    if (usableStrokes.length === 0) {
+      setSignOffError('Capture a signature to continue.')
+      return
+    }
+    const snags = signOffDraft.snagsText
+      .split(/\r?\n/)
+      .map(entry => entry.trim())
+      .filter(entry => entry.length > 0)
+    const signatureDataUrl = canvas.toDataURL('image/png')
+    setIsCompletingSignOff(true)
+    setSignOffError(null)
+    try {
+      const result = await onGenerateCustomerSignOff({
+        name,
+        position,
+        decision: signOffDraft.decision,
+        snags,
+        signatureDataUrl,
+        signaturePaths: usableStrokes,
+        signatureDimensions: { width: canvas.width, height: canvas.height },
+      })
+      if (result) {
+        setSignOffError(result)
+      } else {
+        setIsGeneratingSignOff(false)
+        setSignOffDraft({ name: '', position: '', decision: 'option1', snagsText: '' })
+        resetSignature()
+        setHasSignature(false)
+      }
+    } finally {
+      setIsCompletingSignOff(false)
+    }
+  }
+
+  const handleDownloadSignOffFile = (file: ProjectFile) => {
+    try {
+      const link = document.createElement('a')
+      link.href = file.dataUrl
+      link.download = file.name || 'customer-sign-off'
+      link.rel = 'noopener'
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+    } catch (error) {
+      console.error('Failed to download customer sign off', error)
+      setSignOffError('Unable to download the sign off document.')
+    }
   }
 
   const handleAddWO = async () => {
@@ -362,58 +691,6 @@ export default function ProjectPage({
     }
   }
 
-  const handleAddSignOff = async () => {
-    if (!canEdit) {
-      setSignOffError('You have read-only access.')
-      return
-    }
-    const signedBy = signOffForm.signedBy.trim()
-    if (!signedBy) {
-      setSignOffError('Enter a name for the sign off.')
-      return
-    }
-    setIsSavingSignOff(true)
-    setSignOffError(null)
-    try {
-      const note = signOffForm.note.trim()
-      const result = await onAddSignOff({
-        category: signOffForm.category,
-        signedBy,
-        note: note ? note : undefined,
-      })
-      if (result) {
-        setSignOffError(result)
-      } else {
-        setSignOffForm(prev => ({ category: prev.category, signedBy: currentUser, note: '' }))
-      }
-    } catch (error) {
-      console.error('Failed to add project sign off', error)
-      setSignOffError('Failed to add sign off.')
-    } finally {
-      setIsSavingSignOff(false)
-    }
-  }
-
-  const handleRemoveSignOff = async (signOffId: string) => {
-    if (!canEdit) {
-      setSignOffError('You have read-only access.')
-      return
-    }
-    setRemovingSignOffId(signOffId)
-    setSignOffError(null)
-    try {
-      const result = await onRemoveSignOff(signOffId)
-      if (result) {
-        setSignOffError(result)
-      }
-    } catch (error) {
-      console.error('Failed to remove project sign off', error)
-      setSignOffError('Failed to remove sign off.')
-    } finally {
-      setRemovingSignOffId(null)
-    }
-  }
-
   const renderFilePreview = (file: ProjectFile) => {
     if (isPdfDocument(file)) {
       return <iframe src={file.dataUrl} title={`${file.name} preview`} className='h-60 w-full border-0' />
@@ -428,6 +705,218 @@ export default function ProjectPage({
       </div>
     )
   }
+
+  const renderCustomerSignOffSummary = () => {
+    if (!customerSignOff) {
+      return null
+    }
+    const completedAt = formatTimestamp(customerSignOff.completedAt)
+    const optionCopy = customerSignOff.decision
+      ? CUSTOMER_SIGN_OFF_OPTION_COPY[customerSignOff.decision]
+      : null
+    const snags = customerSignOff.snags ?? []
+    const typeLabel =
+      customerSignOff.type === 'generated' ? 'Generated sign off' : 'Uploaded sign off'
+
+    return (
+      <div className='rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm'>
+        <div className='flex flex-wrap items-start justify-between gap-4'>
+          <div className='space-y-3'>
+            <div>
+              <div className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Status</div>
+              <div className='mt-1 inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700'>
+                {typeLabel}
+              </div>
+            </div>
+            {completedAt && (
+              <div className='text-xs text-slate-500'>Completed {completedAt}</div>
+            )}
+            {customerSignOff.signedByName && (
+              <div className='text-xs text-slate-500'>
+                Signed by {customerSignOff.signedByName}
+                {customerSignOff.signedByPosition ? ` — ${customerSignOff.signedByPosition}` : ''}
+              </div>
+            )}
+            <div className='text-xs text-slate-500'>File: {customerSignOff.file.name}</div>
+            {optionCopy && (
+              <div className='space-y-1'>
+                <div className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Acceptance</div>
+                <div className='text-sm font-semibold text-slate-800'>{optionCopy.title}</div>
+                <p className='text-xs text-slate-500'>{optionCopy.description}</p>
+              </div>
+            )}
+            {snags.length > 0 && (
+              <div className='space-y-1'>
+                <div className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Snag list</div>
+                <ul className='list-disc space-y-1 pl-5 text-xs text-slate-600'>
+                  {snags.map((item, index) => (
+                    <li key={`${customerSignOff.id}-snag-${index}`}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {customerSignOff.signatureDataUrl && (
+              <div>
+                <div className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Signature</div>
+                <div className='mt-2 overflow-hidden rounded-2xl border border-slate-200 bg-white p-3'>
+                  <img
+                    src={customerSignOff.signatureDataUrl}
+                    alt='Customer signature'
+                    className='max-h-40 w-full object-contain'
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+          <div className='flex flex-col items-stretch gap-2'>
+            <Button variant='outline' onClick={() => handleDownloadSignOffFile(customerSignOff.file)}>
+              <Download size={16} /> Download PDF
+            </Button>
+            {canEdit && (
+              <Button
+                variant='outline'
+                onClick={startGeneratingSignOff}
+                disabled={isRemovingSignOff || isUploadingSignOff}
+              >
+                <FileText size={16} /> New Sign Off
+              </Button>
+            )}
+            {canEdit && (
+              <Button
+                variant='ghost'
+                className='text-rose-600 hover:bg-rose-50'
+                onClick={() => void handleRemoveCustomerSignOff()}
+                disabled={isRemovingSignOff}
+              >
+                <Trash2 size={16} /> Remove
+              </Button>
+            )}
+            {isRemovingSignOff && (
+              <span className='text-center text-xs text-slate-500'>Removing…</span>
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const renderCustomerSignOffForm = () => (
+    <div className='rounded-2xl border border-slate-200/80 bg-white/90 p-5 shadow-sm'>
+      <div className='grid gap-4 md:grid-cols-2'>
+        <div>
+          <Label>Signee name</Label>
+          <Input
+            value={signOffDraft.name}
+            onChange={(event) =>
+              setSignOffDraft(prev => ({ ...prev, name: (event.target as HTMLInputElement).value }))
+            }
+            placeholder='Customer name'
+            disabled={isCompletingSignOff || !canEdit}
+          />
+        </div>
+        <div>
+          <Label>Position</Label>
+          <Input
+            value={signOffDraft.position}
+            onChange={(event) =>
+              setSignOffDraft(prev => ({ ...prev, position: (event.target as HTMLInputElement).value }))
+            }
+            placeholder='e.g. Operations Manager'
+            disabled={isCompletingSignOff || !canEdit}
+          />
+        </div>
+      </div>
+      <div className='mt-4 space-y-2'>
+        <Label className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Acceptance</Label>
+        <div className='space-y-2'>
+          {CUSTOMER_SIGN_OFF_OPTIONS.map(option => {
+            const isSelected = signOffDraft.decision === option.value
+            return (
+              <label
+                key={option.value}
+                className={`flex cursor-pointer items-start gap-3 rounded-2xl border px-3 py-2 text-sm transition ${
+                  isSelected
+                    ? 'border-sky-300 bg-sky-50 shadow-sm'
+                    : 'border-slate-200 hover:border-slate-300 hover:bg-slate-50'
+                }`}
+              >
+                <input
+                  type='radio'
+                  className='mt-1'
+                  checked={isSelected}
+                  onChange={() =>
+                    setSignOffDraft(prev => ({ ...prev, decision: option.value }))
+                  }
+                  disabled={isCompletingSignOff || !canEdit}
+                />
+                <div>
+                  <div className='font-semibold text-slate-800'>{option.title}</div>
+                  <p className='text-xs text-slate-500'>{option.description}</p>
+                </div>
+              </label>
+            )
+          })}
+        </div>
+      </div>
+      {(signOffDraft.decision === 'option2' || signOffDraft.decision === 'option3') && (
+        <div className='mt-4'>
+          <Label>Snag list</Label>
+          <textarea
+            className='mt-1 w-full resize-y rounded-xl border border-slate-200/80 bg-white/90 p-3 text-sm text-slate-800 placeholder-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100 disabled:cursor-not-allowed disabled:bg-slate-100/70'
+            rows={3}
+            value={signOffDraft.snagsText}
+            onChange={(event) =>
+              setSignOffDraft(prev => ({ ...prev, snagsText: (event.target as HTMLTextAreaElement).value }))
+            }
+            placeholder='Enter each outstanding item on a new line'
+            disabled={isCompletingSignOff || !canEdit}
+          />
+        </div>
+      )}
+      <div className='mt-4 space-y-2'>
+        <Label>Signature</Label>
+        <p className='text-xs text-slate-500'>Ask the customer to sign below.</p>
+        <div className='overflow-hidden rounded-2xl border border-slate-200 bg-white'>
+          <canvas
+            ref={signatureCanvasRef}
+            className='h-40 w-full'
+            style={{ touchAction: 'none' }}
+            onPointerDown={handleSignaturePointerDown}
+            onPointerMove={handleSignaturePointerMove}
+            onPointerUp={handleSignaturePointerUp}
+            onPointerLeave={handleSignaturePointerLeave}
+          />
+        </div>
+        <div className='flex flex-wrap items-center gap-2'>
+          <Button
+            variant='outline'
+            onClick={() => {
+              resetSignature()
+            }}
+            disabled={isCompletingSignOff || !canEdit}
+          >
+            <X size={16} /> Clear signature
+          </Button>
+          <span className='text-xs text-slate-500'>
+            {hasSignature ? 'Signature captured.' : 'Use your cursor or finger to sign.'}
+          </span>
+        </div>
+      </div>
+      {signOffError && (
+        <p className='mt-4 flex items-center gap-1 text-sm text-rose-600'>
+          <AlertCircle size={14} /> {signOffError}
+        </p>
+      )}
+      <div className='mt-4 flex flex-wrap items-center gap-2'>
+        <Button onClick={() => void handleCompleteSignOff()} disabled={isCompletingSignOff || !canEdit}>
+          {isCompletingSignOff ? 'Saving…' : 'Complete sign off'}
+        </Button>
+        <Button variant='ghost' onClick={cancelGeneratingSignOff} disabled={isCompletingSignOff}>
+          <X size={16} /> Cancel
+        </Button>
+      </div>
+    </div>
+  )
 
   const renderProjectFiles = () => (
     <div className='space-y-6'>
@@ -534,118 +1023,54 @@ export default function ProjectPage({
       </div>
 
       <section className='rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-sm'>
-        <div className='flex flex-wrap items-center justify-between gap-3'>
+        <div className='flex flex-wrap items-start justify-between gap-3'>
           <div>
-            <div className='text-sm font-semibold text-slate-800'>Sign Off</div>
-            <p className='text-xs text-slate-500'>Record approvals for each project area.</p>
+            <div className='text-sm font-semibold text-slate-800'>Customer Sign Off</div>
+            <p className='text-xs text-slate-500'>Upload a signed approval or complete the sign off with your customer.</p>
           </div>
-        </div>
-
-        <div className='mt-4 grid gap-3 md:grid-cols-[minmax(0,220px)_minmax(0,1fr)]'>
-          <div>
-            <Label>Area</Label>
-            <select
-              className='w-full rounded-xl border border-slate-200/80 bg-white/90 px-3 py-2 text-sm text-slate-800 shadow-sm transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100 disabled:cursor-not-allowed disabled:bg-slate-100/70'
-              value={signOffForm.category}
-              onChange={(event) =>
-                setSignOffForm(prev => ({
-                  ...prev,
-                  category: event.target.value as ProjectFileCategory,
-                }))
-              }
-              disabled={isSavingSignOff || !canEdit}
-            >
-              {PROJECT_FILE_CATEGORIES.map(option => (
-                <option key={option} value={option}>
-                  {PROJECT_FILE_METADATA[option].label}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className='grid gap-3 md:grid-cols-2'>
-            <div>
-              <Label>Signed By</Label>
-              <Input
-                value={signOffForm.signedBy}
-                onChange={(event) =>
-                  setSignOffForm(prev => ({ ...prev, signedBy: event.target.value }))
-                }
-                disabled={isSavingSignOff || !canEdit}
-                placeholder='e.g. Jane Smith'
-              />
+          {!isGeneratingSignOff && (
+            <div className='flex flex-wrap items-center gap-2'>
+              <Button
+                onClick={() => uploadSignOffInputRef.current?.click()}
+                disabled={!canEdit || isUploadingSignOff}
+                title={canEdit ? 'Upload customer sign off' : 'Read-only access'}
+              >
+                <Upload size={16} /> Upload File
+              </Button>
+              <Button
+                variant='outline'
+                onClick={startGeneratingSignOff}
+                disabled={!canEdit}
+                title={canEdit ? 'Generate customer sign off' : 'Read-only access'}
+              >
+                <FileText size={16} /> Generate Sign Off
+              </Button>
             </div>
-            <div>
-              <Label>Note (optional)</Label>
-              <textarea
-                className='h-full min-h-[38px] w-full resize-y rounded-xl border border-slate-200/80 bg-white/90 p-2 text-sm text-slate-800 placeholder-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100 disabled:cursor-not-allowed disabled:bg-slate-100/70'
-                rows={2}
-                value={signOffForm.note}
-                onChange={(event) =>
-                  setSignOffForm(prev => ({ ...prev, note: event.target.value }))
-                }
-                disabled={isSavingSignOff || !canEdit}
-                placeholder='Add context for this approval'
-              />
-            </div>
-          </div>
-        </div>
-
-        <div className='mt-3 flex flex-wrap items-center gap-2'>
-          <Button
-            onClick={() => void handleAddSignOff()}
-            disabled={isSavingSignOff || !canEdit}
-            title={canEdit ? 'Add sign off' : 'Read-only access'}
-          >
-            <CheckCircle2 size={16} /> Add Sign Off
-          </Button>
-          {isSavingSignOff && <span className='text-xs text-slate-500'>Saving…</span>}
-          {signOffError && (
-            <span className='flex items-center gap-1 text-sm text-rose-600'>
-              <AlertCircle size={14} /> {signOffError}
-            </span>
           )}
         </div>
-
-        <div className='mt-4 space-y-3'>
-          {signOffs.length === 0 ? (
-            <div className='text-sm text-slate-500'>No sign offs recorded yet.</div>
-          ) : (
-            signOffs.map(entry => {
-              const signedAt = formatTimestamp(entry.signedAt)
-              return (
-                <div
-                  key={entry.id}
-                  className='flex flex-wrap items-start justify-between gap-3 rounded-xl border border-slate-200/70 bg-white/90 p-4'
-                >
-                  <div>
-                    <div className='flex items-center gap-2 text-sm font-semibold text-slate-800'>
-                      <CheckCircle2 size={16} className='text-emerald-500' />
-                      <span>{PROJECT_FILE_METADATA[entry.category].label}</span>
-                    </div>
-                    <div className='mt-1 text-xs text-slate-500'>
-                      Signed by {entry.signedBy}
-                      {signedAt ? ` on ${signedAt}` : ''}
-                    </div>
-                    {entry.note && <div className='mt-1 text-xs text-slate-500'>{entry.note}</div>}
-                  </div>
-                  <div className='flex items-center gap-2'>
-                    <Button
-                      variant='ghost'
-                      className='text-rose-600 hover:bg-rose-50'
-                      onClick={() => void handleRemoveSignOff(entry.id)}
-                      disabled={!canEdit || removingSignOffId === entry.id}
-                      title={canEdit ? 'Remove sign off' : 'Read-only access'}
-                    >
-                      <Trash2 size={16} />
-                    </Button>
-                    {removingSignOffId === entry.id && (
-                      <span className='text-xs text-slate-500'>Removing…</span>
-                    )}
-                  </div>
+        <input
+          ref={uploadSignOffInputRef}
+          type='file'
+          accept={PROJECT_FILE_ACCEPT}
+          className='hidden'
+          onChange={handleSignOffFileChange}
+        />
+        {isUploadingSignOff && <p className='mt-3 text-xs text-slate-500'>Uploading…</p>}
+        {signOffError && !isGeneratingSignOff && (
+          <p className='mt-3 flex items-center gap-1 text-sm text-rose-600'>
+            <AlertCircle size={14} /> {signOffError}
+          </p>
+        )}
+        <div className='mt-4 space-y-4'>
+          {isGeneratingSignOff
+            ? renderCustomerSignOffForm()
+            : customerSignOff
+            ? renderCustomerSignOffSummary()
+            : (
+                <div className='rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-sm text-slate-500'>
+                  No customer sign off recorded yet.
                 </div>
-              )
-            })
-          )}
+              )}
         </div>
       </section>
     </div>
@@ -761,44 +1186,48 @@ export default function ProjectPage({
   return (
     <Card className='panel'>
       <CardHeader className='space-y-5'>
-        <div className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between'>
-          <div className='flex flex-wrap items-center gap-2'>
-            <Button variant='outline' onClick={onNavigateBack}>
-              <ArrowLeft size={16} /> Back to {customer.name}
-            </Button>
-            <Button variant='outline' onClick={onReturnToIndex} title='Return to project index'>
-              <List size={16} /> Return to index
-            </Button>
+        <div className='flex flex-col gap-4 md:flex-row md:items-start md:justify-between'>
+          <div className='flex flex-col gap-3'>
+            <div className='flex flex-wrap items-center gap-2'>
+              <Button variant='outline' onClick={onNavigateBack}>
+                <ArrowLeft size={16} /> Back to {customer.name}
+              </Button>
+            </div>
+            <nav className='flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500'>
+              <button
+                type='button'
+                onClick={onReturnToIndex}
+                className='inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium text-slate-600 transition hover:text-slate-900'
+              >
+                Projects
+              </button>
+              <ChevronRight size={12} className='text-slate-400' />
+              <span className='text-slate-800'>{project.number}</span>
+            </nav>
           </div>
           <div className='flex flex-wrap items-center gap-2'>
             <div className='flex flex-col items-stretch gap-2 text-right'>
               <Label className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Status</Label>
-              <div className='flex flex-wrap items-center justify-end gap-2'>
+              <div className='flex items-center justify-end gap-2'>
+                <span
+                  className={`h-2.5 w-2.5 rounded-full ${
+                    statusSelectionOption?.indicatorClass ?? 'bg-slate-300'
+                  }`}
+                />
                 <select
-                  className='rounded-xl border border-slate-200/80 bg-white/90 px-3 py-2 text-sm text-slate-800 shadow-sm transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100 disabled:cursor-not-allowed disabled:bg-slate-100/70'
-                  value={statusDraft}
-                  onChange={(event) => handleStatusChange(event.target.value as ProjectStatus)}
+                  className={`rounded-xl border px-3 py-2 text-sm font-medium shadow-sm transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100 disabled:cursor-not-allowed ${
+                    statusSelectionOption?.selectClass ?? 'border-slate-200 bg-white text-slate-800'
+                  }`}
+                  value={statusSelectionValue}
+                  onChange={(event) => handleStatusSelectionChange(event.target.value)}
                   disabled={!canEdit}
                 >
-                  <option value='Active'>Active</option>
-                  <option value='Complete'>Complete</option>
+                  {STATUS_SELECTIONS.map(option => (
+                    <option key={option.key} value={option.key}>
+                      {option.label}
+                    </option>
+                  ))}
                 </select>
-                {statusDraft === 'Active' && (
-                  <select
-                    className='rounded-xl border border-slate-200/80 bg-white/90 px-3 py-2 text-sm text-slate-800 shadow-sm transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100 disabled:cursor-not-allowed disabled:bg-slate-100/70'
-                    value={activeSubStatusDraft}
-                    onChange={(event) =>
-                      handleActiveSubStatusChange(event.target.value as ProjectActiveSubStatus)
-                    }
-                    disabled={!canEdit}
-                  >
-                    {PROJECT_ACTIVE_SUB_STATUS_OPTIONS.map(option => (
-                      <option key={option} value={option}>
-                        {option}
-                      </option>
-                    ))}
-                  </select>
-                )}
               </div>
               {latestStatusEntry && (
                 <div className='flex items-center justify-end gap-1 text-xs text-slate-500'>
@@ -819,6 +1248,30 @@ export default function ProjectPage({
               <span className='sr-only'>Copy project number</span>
             </Button>
             <Button
+              variant='outline'
+              onClick={() => {
+                if (isEditingNote) {
+                  setIsEditingNote(false)
+                  setNoteDraft(project.note ?? '')
+                } else {
+                  setIsEditingNote(true)
+                  setNoteDraft(project.note ?? '')
+                }
+              }}
+              title={canEdit ? 'Edit project note' : 'Read-only access'}
+              disabled={!canEdit}
+            >
+              {isEditingNote ? (
+                <>
+                  <X size={16} /> Cancel edit
+                </>
+              ) : (
+                <>
+                  <Pencil size={16} /> Edit note
+                </>
+              )}
+            </Button>
+            <Button
               variant='ghost'
               className='text-rose-600 hover:bg-rose-50'
               onClick={() => {
@@ -835,21 +1288,50 @@ export default function ProjectPage({
         </div>
 
         <div className='space-y-3'>
-          <div className='text-lg font-semibold text-slate-800'>Project: {project.number}</div>
-          <div>
-            <Label className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Project Note</Label>
-            <textarea
-              className='mt-1 w-full resize-y rounded-xl border border-slate-200/80 bg-white/90 p-3 text-sm text-slate-800 placeholder-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100 disabled:cursor-not-allowed disabled:bg-slate-100/70'
-              rows={3}
-              value={noteDraft}
-              placeholder='Add a note about this project (optional)…'
-              onChange={(event) => {
-                const next = event.target.value
-                setNoteDraft(next)
-                onUpdateProjectNote(next)
-              }}
-              disabled={!canEdit}
-            />
+          <div className='text-lg font-semibold text-slate-800'>{project.number}</div>
+          <div className='rounded-2xl border border-slate-200 bg-white/90 p-4'>
+            {isEditingNote ? (
+              <>
+                <textarea
+                  className='w-full resize-y rounded-xl border border-slate-200/80 bg-white/90 p-3 text-sm text-slate-800 placeholder-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100 disabled:cursor-not-allowed disabled:bg-slate-100/70'
+                  rows={3}
+                  value={noteDraft}
+                  onChange={(event) => setNoteDraft(event.target.value)}
+                  placeholder='Add a note about this project (optional)…'
+                  disabled={!canEdit}
+                />
+                <div className='mt-3 flex flex-wrap items-center gap-2'>
+                  <Button
+                    onClick={() => {
+                      onUpdateProjectNote(noteDraft)
+                      setIsEditingNote(false)
+                    }}
+                    disabled={!canEdit}
+                  >
+                    Save note
+                  </Button>
+                  <Button
+                    variant='ghost'
+                    onClick={() => {
+                      setNoteDraft(project.note ?? '')
+                      setIsEditingNote(false)
+                    }}
+                  >
+                    <X size={16} /> Cancel
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <p
+                className={
+                  project.note
+                    ? 'whitespace-pre-wrap text-sm text-slate-700'
+                    : 'text-sm italic text-slate-400'
+                }
+              >
+                {project.note ? project.note : 'No note added yet.'}
+              </p>
+            )}
           </div>
           {statusHistory.length > 1 && (
             <div>

--- a/src/lib/signOff.ts
+++ b/src/lib/signOff.ts
@@ -1,0 +1,380 @@
+import {
+  CUSTOMER_SIGN_OFF_DECISIONS,
+  type CustomerSignOffDecision,
+  type CustomerSignOffSignatureDimensions,
+  type CustomerSignOffSignatureStroke,
+} from '../types'
+
+export const CUSTOMER_SIGN_OFF_OPTION_COPY: Record<
+  CustomerSignOffDecision,
+  { title: string; description: string }
+> = {
+  option1: {
+    title: 'Option 1 — Completed without issues',
+    description:
+      'Installation was completed successfully with no outstanding issues and the system is running/ready to run. I authorise invoicing of the Final Acceptance within 10 days unless Cobalt are notified in writing of any further issues.',
+  },
+  option2: {
+    title: 'Option 2 — Completed with outstanding issues',
+    description:
+      'Installation was completed and the system is running/ready to run, but there are outstanding issues that have been agreed with the Installation Engineer that require resolving. A plan will be agreed to ensure these points are addressed and the system will be invoiced 10 days from completion or within 60 days from today as per Cobalt Systems standard terms.',
+  },
+  option3: {
+    title: 'Option 3 — Installation incomplete',
+    description:
+      'Installation is not complete and the line cannot be run. Cobalt Systems will complete any additional work required and return to complete the installation at an agreed upon date.',
+  },
+}
+
+export const CUSTOMER_SIGN_OFF_OPTIONS = CUSTOMER_SIGN_OFF_DECISIONS.map(value => ({
+  value,
+  ...CUSTOMER_SIGN_OFF_OPTION_COPY[value],
+}))
+
+type Rgb = [number, number, number]
+
+export type CustomerSignOffPdfInput = {
+  projectNumber: string
+  customerName: string
+  signedByName: string
+  signedByPosition: string
+  decision: CustomerSignOffDecision
+  snags: string[]
+  signaturePaths: CustomerSignOffSignatureStroke[]
+  signatureDimensions: CustomerSignOffSignatureDimensions
+  completedAt: string
+}
+
+function escapePdfText(text: string): string {
+  return text.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)')
+}
+
+function createTextMeasurer() {
+  if (typeof document !== 'undefined') {
+    const canvas = document.createElement('canvas')
+    const context = canvas.getContext('2d')
+    if (context) {
+      return (text: string, fontSize: number, isBold: boolean) => {
+        const pxFontSize = fontSize * (96 / 72)
+        context.font = `${isBold ? '600 ' : ''}${pxFontSize}px Helvetica`
+        return context.measureText(text).width * (72 / 96)
+      }
+    }
+  }
+  return (text: string, fontSize: number, isBold: boolean) =>
+    text.length * fontSize * (isBold ? 0.62 : 0.6)
+}
+
+function wrapText(
+  text: string,
+  maxWidth: number,
+  fontSize: number,
+  isBold: boolean,
+  measure: (text: string, fontSize: number, isBold: boolean) => number,
+): string[] {
+  const lines: string[] = []
+  const paragraphs = text.split(/\r?\n/)
+
+  for (const paragraph of paragraphs) {
+    const words = paragraph.split(/\s+/).filter(Boolean)
+    if (words.length === 0) {
+      lines.push('')
+      continue
+    }
+
+    let current = words.shift() as string
+    for (const word of words) {
+      const candidate = `${current} ${word}`
+      if (measure(candidate, fontSize, isBold) <= maxWidth) {
+        current = candidate
+      } else {
+        lines.push(current)
+        current = word
+      }
+    }
+    lines.push(current)
+  }
+
+  return lines
+}
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) < 1e-6) {
+    return '0'
+  }
+  const fixed = value.toFixed(2)
+  return fixed.endsWith('.00') ? fixed.slice(0, -3) : fixed
+}
+
+function appendTextLine(
+  builder: { content: string },
+  text: string,
+  x: number,
+  y: number,
+  fontKey: 'F1' | 'F2',
+  fontSize: number,
+  color: Rgb,
+) {
+  const [r, g, b] = color
+  builder.content +=
+    `BT\n/${fontKey} ${formatNumber(fontSize)} Tf\n${formatNumber(r)} ${formatNumber(g)} ${formatNumber(b)} rg\n1 0 0 1 ${formatNumber(
+      x,
+    )} ${formatNumber(y)} Tm\n(${escapePdfText(text)}) Tj\nET\n`
+}
+
+function drawRectangle(
+  builder: { content: string },
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  fill: Rgb,
+  stroke: Rgb,
+) {
+  const [fr, fg, fb] = fill
+  const [sr, sg, sb] = stroke
+  builder.content += `${formatNumber(fr)} ${formatNumber(fg)} ${formatNumber(fb)} rg\n`
+  builder.content += `${formatNumber(sr)} ${formatNumber(sg)} ${formatNumber(sb)} RG\n1 w\n`
+  builder.content += `${formatNumber(x)} ${formatNumber(y)} ${formatNumber(width)} ${formatNumber(height)} re B\n`
+}
+
+function drawSignaturePaths(
+  builder: { content: string },
+  strokes: CustomerSignOffSignatureStroke[],
+  dimensions: CustomerSignOffSignatureDimensions,
+  box: { x: number; y: number; width: number; height: number },
+) {
+  if (!strokes.length || dimensions.width <= 0 || dimensions.height <= 0) {
+    return
+  }
+
+  const padding = 12
+  const availableWidth = Math.max(box.width - padding * 2, 1)
+  const availableHeight = Math.max(box.height - padding * 2, 1)
+  const scale = Math.min(availableWidth / dimensions.width, availableHeight / dimensions.height)
+  const offsetX = box.x + padding + (availableWidth - dimensions.width * scale) / 2
+  const offsetY = box.y + padding + (availableHeight - dimensions.height * scale) / 2
+
+  builder.content += `${formatNumber(0.07)} ${formatNumber(0.07)} ${formatNumber(0.07)} RG\n1.5 w\n`
+
+  for (const stroke of strokes) {
+    if (!stroke || stroke.length < 2) {
+      continue
+    }
+    const start = stroke[0]
+    const startX = offsetX + start.x * scale
+    const startY = offsetY + (dimensions.height - start.y) * scale
+    builder.content += `${formatNumber(startX)} ${formatNumber(startY)} m\n`
+    for (let index = 1; index < stroke.length; index += 1) {
+      const point = stroke[index]
+      const x = offsetX + point.x * scale
+      const y = offsetY + (dimensions.height - point.y) * scale
+      builder.content += `${formatNumber(x)} ${formatNumber(y)} l\n`
+    }
+    builder.content += 'S\n'
+  }
+}
+
+type PdfObject =
+  | { type: 'value'; content: string }
+  | { type: 'stream'; content: Uint8Array }
+
+function buildPdf(objects: PdfObject[]): Uint8Array {
+  const encoder = new TextEncoder()
+  const chunks: Uint8Array[] = []
+  const offsets: number[] = [0]
+  let offset = 0
+
+  const header = encoder.encode('%PDF-1.4\n')
+  chunks.push(header)
+  offset += header.length
+
+  objects.forEach((object, index) => {
+    offsets.push(offset)
+    const id = index + 1
+    if (object.type === 'value') {
+      const body = encoder.encode(`${id} 0 obj\n${object.content}\nendobj\n`)
+      chunks.push(body)
+      offset += body.length
+    } else {
+      const start = encoder.encode(`${id} 0 obj\n<< /Length ${object.content.length} >>\nstream\n`)
+      const end = encoder.encode('\nendstream\nendobj\n')
+      chunks.push(start, object.content, end)
+      offset += start.length + object.content.length + end.length
+    }
+  })
+
+  const xrefOffset = offset
+  const xrefHeader = encoder.encode(`xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`)
+  chunks.push(xrefHeader)
+  offset += xrefHeader.length
+
+  const xrefEntries = objects
+    .map((_, index) => `${offsets[index + 1].toString().padStart(10, '0')} 00000 n \n`)
+    .join('')
+  const xrefBody = encoder.encode(xrefEntries)
+  chunks.push(xrefBody)
+  offset += xrefBody.length
+
+  const trailer = encoder.encode(
+    `trailer\n<< /Size ${objects.length + 1} /Root ${objects.length} 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`,
+  )
+  chunks.push(trailer)
+
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+  const pdfBytes = new Uint8Array(totalLength)
+  let position = 0
+  for (const chunk of chunks) {
+    pdfBytes.set(chunk, position)
+    position += chunk.length
+  }
+
+  return pdfBytes
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  if (typeof btoa === 'function') {
+    let binary = ''
+    const chunkSize = 0x8000
+    for (let index = 0; index < bytes.length; index += chunkSize) {
+      const chunk = bytes.subarray(index, index + chunkSize)
+      binary += String.fromCharCode(...Array.from(chunk))
+    }
+    return btoa(binary)
+  }
+
+  const potentialBuffer = (globalThis as {
+    Buffer?: { from(input: Uint8Array): { toString(encoding: string): string } }
+  }).Buffer
+  if (potentialBuffer) {
+    return potentialBuffer.from(bytes).toString('base64')
+  }
+
+  throw new Error('No base64 encoder available')
+}
+
+export async function generateCustomerSignOffPdf(data: CustomerSignOffPdfInput): Promise<string> {
+  const pageWidth = 595.28
+  const pageHeight = 841.89
+  const margin = 48
+  const contentWidth = pageWidth - margin * 2
+
+  const headingColor: Rgb = [0.1, 0.13, 0.2]
+  const labelColor: Rgb = [0.4, 0.45, 0.55]
+  const bodyColor: Rgb = [0.1, 0.13, 0.2]
+  const accentColor: Rgb = [0.15, 0.18, 0.26]
+  const bulletColor: Rgb = [0.3, 0.2, 0.2]
+
+  const measure = createTextMeasurer()
+  const builder = { content: '' }
+  let cursor = pageHeight - margin
+
+  const wrap = (text: string, width: number, size: number, isBold: boolean) =>
+    wrapText(text, width, size, isBold, measure)
+
+  const drawHeading = (text: string, size: number, gap: number) => {
+    cursor -= size
+    appendTextLine(builder, text, margin, cursor, 'F2', size, headingColor)
+    cursor -= gap
+  }
+
+  const drawLabelValue = (label: string, value: string) => {
+    const labelSize = 11
+    const valueSize = 12
+    cursor -= labelSize
+    appendTextLine(builder, label.toUpperCase(), margin, cursor, 'F2', labelSize, labelColor)
+    cursor -= 4
+    const lines = value ? wrap(value, contentWidth, valueSize, false) : ['—']
+    for (let index = 0; index < lines.length; index += 1) {
+      cursor -= valueSize
+      appendTextLine(builder, lines[index], margin, cursor, 'F1', valueSize, bodyColor)
+      cursor -= 4
+    }
+    cursor -= 8
+  }
+
+  drawHeading('Customer Sign Off', 24, 24)
+  drawLabelValue('Customer', data.customerName)
+  drawLabelValue('Project', data.projectNumber)
+  const completedDisplay = new Date(data.completedAt).toLocaleString()
+  drawLabelValue('Completed', completedDisplay)
+
+  const optionCopy = CUSTOMER_SIGN_OFF_OPTION_COPY[data.decision]
+  drawHeading('Acceptance Statement', 16, 16)
+  const titleLines = wrap(optionCopy.title, contentWidth, 13, true)
+  for (let index = 0; index < titleLines.length; index += 1) {
+    cursor -= 13
+    appendTextLine(builder, titleLines[index], margin, cursor, 'F2', 13, accentColor)
+    cursor -= index === titleLines.length - 1 ? 10 : 4
+  }
+
+  const descriptionLines = wrap(optionCopy.description, contentWidth, 12, false)
+  for (let index = 0; index < descriptionLines.length; index += 1) {
+    cursor -= 12
+    appendTextLine(builder, descriptionLines[index], margin, cursor, 'F1', 12, bodyColor)
+    cursor -= index === descriptionLines.length - 1 ? 16 : 4
+  }
+
+  if (data.snags.length > 0) {
+    drawHeading('Snag List', 16, 12)
+    for (const snag of data.snags) {
+      const lines = wrap(snag, contentWidth - 18, 12, false)
+      for (let index = 0; index < lines.length; index += 1) {
+        cursor -= 12
+        const prefix = index === 0 ? '• ' : '  '
+        appendTextLine(builder, `${prefix}${lines[index]}`, margin, cursor, 'F1', 12, bulletColor)
+        cursor -= 4
+      }
+      cursor -= 4
+    }
+  }
+
+  cursor -= 12
+  drawHeading('Authorisation', 16, 20)
+
+  const signatureBoxHeight = 120
+  const signatureBoxTop = cursor
+  const signatureBoxBottom = signatureBoxTop - signatureBoxHeight
+
+  drawRectangle(
+    builder,
+    margin,
+    signatureBoxBottom,
+    contentWidth,
+    signatureBoxHeight,
+    [0.96, 0.97, 0.99],
+    [0.8, 0.82, 0.86],
+  )
+
+  drawSignaturePaths(builder, data.signaturePaths, data.signatureDimensions, {
+    x: margin,
+    y: signatureBoxBottom,
+    width: contentWidth,
+    height: signatureBoxHeight,
+  })
+
+  cursor = signatureBoxBottom - 24
+  const signedBy = `${data.signedByName} — ${data.signedByPosition}`
+  drawLabelValue('Signed by', signedBy)
+
+  const contentStream = builder.content
+  const contentBytes = new TextEncoder().encode(contentStream)
+
+  const objects: PdfObject[] = []
+  objects.push({ type: 'value', content: '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>' })
+  objects.push({ type: 'value', content: '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>' })
+  objects.push({ type: 'stream', content: contentBytes })
+
+  const predictedPagesId = objects.length + 2
+  const pageObject =
+    `<< /Type /Page /Parent ${predictedPagesId} 0 R /MediaBox [0 0 ${formatNumber(pageWidth)} ${formatNumber(
+      pageHeight,
+    )}] /Resources << /Font << /F1 1 0 R /F2 2 0 R >> >> /Contents 3 0 R >>`
+  objects.push({ type: 'value', content: pageObject })
+  objects.push({ type: 'value', content: `<< /Type /Pages /Kids [4 0 R] /Count 1 >>` })
+  objects.push({ type: 'value', content: '<< /Type /Catalog /Pages 5 0 R >>' })
+
+  const pdfBytes = buildPdf(objects)
+  const base64 = encodeBase64(pdfBytes)
+  return `data:application/pdf;base64,${base64}`
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,12 +41,36 @@ export type ProjectStatusLogEntry = {
   changedBy: string;
 };
 
-export type ProjectSignOff = {
+export type CustomerSignOffDecision = 'option1' | 'option2' | 'option3';
+
+export const CUSTOMER_SIGN_OFF_DECISIONS: CustomerSignOffDecision[] = ['option1', 'option2', 'option3'];
+
+export type CustomerSignOffSignaturePoint = { x: number; y: number };
+
+export type CustomerSignOffSignatureStroke = CustomerSignOffSignaturePoint[];
+
+export type CustomerSignOffSignatureDimensions = { width: number; height: number };
+
+export type ProjectCustomerSignOff = {
   id: string;
-  category: ProjectFileCategory;
-  signedAt: string;
-  signedBy: string;
-  note?: string;
+  type: 'upload' | 'generated';
+  completedAt: string;
+  file: ProjectFile;
+  signedByName?: string;
+  signedByPosition?: string;
+  decision?: CustomerSignOffDecision;
+  snags?: string[];
+  signatureDataUrl?: string;
+};
+
+export type CustomerSignOffSubmission = {
+  name: string;
+  position: string;
+  decision: CustomerSignOffDecision;
+  snags: string[];
+  signatureDataUrl: string;
+  signaturePaths: CustomerSignOffSignatureStroke[];
+  signatureDimensions: CustomerSignOffSignatureDimensions;
 };
 
 export type Project = {
@@ -58,7 +82,7 @@ export type Project = {
   wos: WO[];
   documents?: ProjectDocuments;
   statusHistory?: ProjectStatusLogEntry[];
-  signOffs?: ProjectSignOff[];
+  customerSignOff?: ProjectCustomerSignOff;
 };
 
 export type CustomerContact = {


### PR DESCRIPTION
## Summary
- refresh the project detail layout with breadcrumb navigation, color-coded status selection, and inline note editing
- replace the legacy document sign-off flow with a customer sign-off experience that supports uploads, on-site capture with signature, PDF generation, and detailed summaries
- persist the new customer sign-off data model, add manual PDF creation utilities, and simplify the contact panel so only phone and email copy helpers remain

## Testing
- npm run build *(fails: local Vite binary lacks execute permission)*
- node node_modules/vite/bin/vite.js build

------
https://chatgpt.com/codex/tasks/task_e_68d3de5735ac8321ad80070d94ed41d6