### PR TITLE
Implement project info management and user administration

### DIFF
--- a/src/lib/projectInfo.ts
+++ b/src/lib/projectInfo.ts
@@ -1,0 +1,95 @@
+import type { ProjectInfo, User } from '../types'
+
+export type ProjectInfoDraft = {
+  lineReference: string
+  machineSerialNumbers: string
+  toolSerialNumbers: string
+  cobaltOrderNumber: string
+  customerOrderNumber: string
+  salespersonId: string
+  startDate: string
+  proposedCompletionDate: string
+}
+
+export function createProjectInfoDraft(info: ProjectInfo | undefined, users: User[]): ProjectInfoDraft {
+  let salespersonId = info?.salespersonId ?? ''
+  if (salespersonId && !users.some(user => user.id === salespersonId)) {
+    salespersonId = ''
+  }
+
+  if (!salespersonId && info?.salespersonName) {
+    const match = users.find(
+      user => user.name.trim().toLowerCase() === info.salespersonName!.trim().toLowerCase(),
+    )
+    if (match) {
+      salespersonId = match.id
+    }
+  }
+
+  return {
+    lineReference: info?.lineReference ?? '',
+    machineSerialNumbers: info?.machineSerialNumbers?.join('\n') ?? '',
+    toolSerialNumbers: info?.toolSerialNumbers?.join('\n') ?? '',
+    cobaltOrderNumber: info?.cobaltOrderNumber ?? '',
+    customerOrderNumber: info?.customerOrderNumber ?? '',
+    salespersonId,
+    startDate: info?.startDate ?? '',
+    proposedCompletionDate: info?.proposedCompletionDate ?? '',
+  }
+}
+
+export function parseProjectInfoDraft(
+  draft: ProjectInfoDraft,
+  users: User[],
+): { info: ProjectInfo | null; error?: string } {
+  const lineReference = draft.lineReference.trim()
+  const machineSerialNumbers = draft.machineSerialNumbers
+    .split(/\r?\n/)
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0)
+  const toolSerialNumbers = draft.toolSerialNumbers
+    .split(/\r?\n/)
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0)
+  const cobaltOrderNumber = draft.cobaltOrderNumber.trim()
+  const customerOrderNumber = draft.customerOrderNumber.trim()
+  const startDate = draft.startDate.trim()
+  if (startDate && !/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
+    return { info: null, error: 'Enter a valid project start date (YYYY-MM-DD).' }
+  }
+  const proposedCompletionDate = draft.proposedCompletionDate.trim()
+  if (proposedCompletionDate && !/^\d{4}-\d{2}-\d{2}$/.test(proposedCompletionDate)) {
+    return { info: null, error: 'Enter a valid proposed completion date (YYYY-MM-DD).' }
+  }
+
+  let salespersonId: string | undefined
+  let salespersonName: string | undefined
+  if (draft.salespersonId) {
+    const user = users.find(entry => entry.id === draft.salespersonId)
+    if (!user) {
+      return { info: null, error: 'Select a valid salesperson.' }
+    }
+    salespersonId = user.id
+    salespersonName = user.name
+  }
+
+  const info: ProjectInfo = {}
+  if (lineReference) info.lineReference = lineReference
+  if (machineSerialNumbers.length > 0) info.machineSerialNumbers = machineSerialNumbers
+  if (toolSerialNumbers.length > 0) info.toolSerialNumbers = toolSerialNumbers
+  if (cobaltOrderNumber) info.cobaltOrderNumber = cobaltOrderNumber
+  if (customerOrderNumber) info.customerOrderNumber = customerOrderNumber
+  if (salespersonId) info.salespersonId = salespersonId
+  if (salespersonName) info.salespersonName = salespersonName
+  if (startDate) info.startDate = startDate
+  if (proposedCompletionDate) info.proposedCompletionDate = proposedCompletionDate
+
+  const hasInfo = Object.values(info).some(value => {
+    if (Array.isArray(value)) {
+      return value.length > 0
+    }
+    return value !== undefined
+  })
+
+  return { info: hasInfo ? info : null }
+}

--- a/src/lib/signOff.ts
+++ b/src/lib/signOff.ts
@@ -36,6 +36,14 @@ type Rgb = [number, number, number]
 export type CustomerSignOffPdfInput = {
   projectNumber: string
   customerName: string
+  lineReference?: string
+  machineSerialNumbers?: string[]
+  toolSerialNumbers?: string[]
+  cobaltOrderNumber?: string
+  customerOrderNumber?: string
+  salespersonName?: string
+  startDate?: string
+  proposedCompletionDate?: string
   signedByName: string
   signedByPosition: string
   decision: CustomerSignOffDecision
@@ -272,6 +280,24 @@ export async function generateCustomerSignOffPdf(data: CustomerSignOffPdfInput):
   const wrap = (text: string, width: number, size: number, isBold: boolean) =>
     wrapText(text, width, size, isBold, measure)
 
+  const formatList = (items?: string[]): string => {
+    if (!items || items.length === 0) {
+      return 'Not provided'
+    }
+    return items.join(', ')
+  }
+
+  const formatDateValue = (value?: string): string => {
+    if (!value) {
+      return 'Not provided'
+    }
+    const parsed = Date.parse(value)
+    if (Number.isNaN(parsed)) {
+      return value
+    }
+    return new Date(parsed).toLocaleDateString()
+  }
+
   const drawHeading = (text: string, size: number, gap: number) => {
     cursor -= size
     appendTextLine(builder, text, margin, cursor, 'F2', size, headingColor)
@@ -298,6 +324,16 @@ export async function generateCustomerSignOffPdf(data: CustomerSignOffPdfInput):
   drawLabelValue('Project', data.projectNumber)
   const completedDisplay = new Date(data.completedAt).toLocaleString()
   drawLabelValue('Completed', completedDisplay)
+
+  drawHeading('Project Information', 16, 16)
+  drawLabelValue('Line No/Name', data.lineReference ?? 'Not provided')
+  drawLabelValue('Machine Serial Numbers', formatList(data.machineSerialNumbers))
+  drawLabelValue('Tool Serial Numbers', formatList(data.toolSerialNumbers))
+  drawLabelValue('Cobalt Order Number', data.cobaltOrderNumber ?? 'Not provided')
+  drawLabelValue('Customer Order Number', data.customerOrderNumber ?? 'Not provided')
+  drawLabelValue('Salesperson', data.salespersonName ?? 'Not provided')
+  drawLabelValue('Project Start Date', formatDateValue(data.startDate))
+  drawLabelValue('Proposed Completion', formatDateValue(data.proposedCompletionDate))
 
   const optionCopy = CUSTOMER_SIGN_OFF_OPTION_COPY[data.decision]
   drawHeading('Acceptance Statement', 16, 16)

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,18 @@ export type ProjectStatusLogEntry = {
   changedBy: string;
 };
 
+export type ProjectInfo = {
+  lineReference?: string;
+  machineSerialNumbers?: string[];
+  toolSerialNumbers?: string[];
+  cobaltOrderNumber?: string;
+  customerOrderNumber?: string;
+  salespersonId?: string;
+  salespersonName?: string;
+  startDate?: string;
+  proposedCompletionDate?: string;
+};
+
 export type CustomerSignOffDecision = 'option1' | 'option2' | 'option3';
 
 export const CUSTOMER_SIGN_OFF_DECISIONS: CustomerSignOffDecision[] = ['option1', 'option2', 'option3'];
@@ -72,6 +84,7 @@ export type ProjectCustomerSignOff = {
   decision?: CustomerSignOffDecision;
   snags?: string[];
   signatureDataUrl?: string;
+  projectInfo?: ProjectInfo;
 };
 
 export type CustomerSignOffSubmission = {
@@ -94,7 +107,8 @@ export type ProjectTask = {
   status: ProjectTaskStatus;
   start?: string;
   end?: string;
-  assignee?: string;
+  assigneeId?: string;
+  assigneeName?: string;
 };
 
 export type Project = {
@@ -108,6 +122,7 @@ export type Project = {
   statusHistory?: ProjectStatusLogEntry[];
   customerSignOff?: ProjectCustomerSignOff;
   tasks?: ProjectTask[];
+  info?: ProjectInfo;
 };
 
 export type CustomerContact = {
@@ -127,6 +142,17 @@ export type Customer = {
 };
 
 export type AppRole = 'viewer' | 'editor' | 'admin';
+
+export type TwoFactorMethod = 'authenticator' | 'sms';
+
+export type User = {
+  id: string;
+  name: string;
+  email?: string;
+  role: AppRole;
+  twoFactorEnabled: boolean;
+  twoFactorMethod?: TwoFactorMethod;
+};
 
 export function formatProjectStatus(status: ProjectStatus, activeSubStatus?: ProjectActiveSubStatus): string {
   if (status === 'Active') {


### PR DESCRIPTION
## Summary
- add project info draft utilities plus extended types and storage for enhanced metadata, user entities, and default task templates
- overhaul application shell with expanded project creation modal, user management settings, import handling, and sign-off integration of project info
- refresh project detail page to prioritize tasks, add rich project info editor, and require assignees to come from managed users

## Testing
- `npx tsc -b`
- `node node_modules/vite/bin/vite.js build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d5a90c010483219d910050ed03f5bf