### PR TITLE
Add authentication flow and reorganize settings tabs

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -148,10 +148,11 @@ export type TwoFactorMethod = 'authenticator' | 'sms';
 export type User = {
   id: string;
   name: string;
-  email?: string;
+  email: string;
   role: AppRole;
   twoFactorEnabled: boolean;
   twoFactorMethod?: TwoFactorMethod;
+  passwordHash: string;
 };
 
 export function formatProjectStatus(status: ProjectStatus, activeSubStatus?: ProjectActiveSubStatus): string {


### PR DESCRIPTION
## Summary
- add an email/password sign-in flow with logout support, password strength feedback, and demo credentials on the login screen
- split the settings area into user management and import/export tabs, including new user creation/edit forms with password validation
- require normalized emails and hashed passwords in local storage while updating modal layouts to use scrollable cards for large forms

## Testing
- npx tsc -b
- npm run build *(fails: `vite` binary is not executable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6496d15f08321a298f6243d0b99f7