### PR TITLE
Fix premature logout while user list loads

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -527,13 +527,13 @@ function AppContent() {
   }, [sessionUserId, isSessionReady])
 
   useEffect(() => {
-    if (!sessionUserId) {
+    if (!sessionUserId || isLoading) {
       return
     }
     if (!users.some(user => user.id === sessionUserId)) {
       setSessionUserId(null)
     }
-  }, [users, sessionUserId])
+  }, [users, sessionUserId, isLoading])
 
   useEffect(() => {
     if (sessionUserId) {


### PR DESCRIPTION
## Summary
- avoid clearing the active session while the initial user list is still loading so demo sign-in succeeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d652e9f1f8832192c8b90b51c4c277