### PR TITLE
Fix login by migrating legacy localStorage data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ npm run preview
 ```
 
 ## Data
-All data is stored in the browser `localStorage` under key `cpdb.v1`. Clearing browser storage resets the demo database.
+All data is stored in the browser `localStorage` under key `customer-project-db` (older `cpdb.v1` data is migrated automatically).
+Clearing browser storage resets the demo database.
 
 
 ## GitHub Setup

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -304,6 +304,7 @@ function createLocalStorageStorage(): StorageApi {
   }
 
   const STORAGE_KEY = 'customer-project-db'
+  const LEGACY_STORAGE_KEYS = ['cpdb.v1'] as const
   const memoryStorage: StorageLike = (() => {
     const store = new Map<string, string>()
     return {
@@ -1038,17 +1039,49 @@ function createLocalStorageStorage(): StorageApi {
     return { customers: sortCustomers(customers), users: normalizedUsers }
   }
 
+  function readStoredDatabase(storage: StorageLike): { key: string; value: string } | null {
+    const currentValue = storage.getItem(STORAGE_KEY)
+    if (currentValue) {
+      return { key: STORAGE_KEY, value: currentValue }
+    }
+
+    for (const legacyKey of LEGACY_STORAGE_KEYS) {
+      const legacyValue = storage.getItem(legacyKey)
+      if (legacyValue) {
+        return { key: legacyKey, value: legacyValue }
+      }
+    }
+
+    return null
+  }
+
   function loadDatabase(): Database {
     const storage = resolveStorage()
-    const raw = storage.getItem(STORAGE_KEY)
-    if (!raw) {
+    const stored = readStoredDatabase(storage)
+    if (!stored) {
       return { customers: [], users: ensureDefaultUsers([]) }
     }
 
     try {
-      const parsed = JSON.parse(raw) as unknown
-      return normalizeDatabase(parsed)
+      const parsed = JSON.parse(stored.value) as unknown
+      const normalized = normalizeDatabase(parsed)
+      if (stored.key !== STORAGE_KEY) {
+        try {
+          storage.setItem(STORAGE_KEY, JSON.stringify(normalized))
+          storage.removeItem(stored.key)
+        } catch {
+          // Ignore migration write failures so the session can continue with in-memory data.
+        }
+      }
+      return normalized
     } catch {
+      if (stored.key !== STORAGE_KEY) {
+        try {
+          storage.removeItem(stored.key)
+        } catch {
+          // Ignore failures to clean up invalid legacy data.
+        }
+      }
       return { customers: [], users: ensureDefaultUsers([]) }
     }
   }
@@ -1057,6 +1090,15 @@ function createLocalStorageStorage(): StorageApi {
     const storage = resolveStorage()
     const normalized = normalizeDatabase(db)
     storage.setItem(STORAGE_KEY, JSON.stringify(normalized))
+    for (const legacyKey of LEGACY_STORAGE_KEYS) {
+      if (legacyKey !== STORAGE_KEY) {
+        try {
+          storage.removeItem(legacyKey)
+        } catch {
+          // Ignore removal errors; they only affect optional clean-up of legacy data.
+        }
+      }
+    }
   }
 
   function cloneWorkOrder(wo: WO): WO {


### PR DESCRIPTION
## Summary
- load legacy `cpdb.v1` localStorage data when the current `customer-project-db` key is empty and migrate it forward
- clean up stale legacy keys after saving the database to keep storage consistent
- document the storage key change and automatic migration in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d65aa360848321b343e2277b165103