### PR TITLE
Add business metadata scaffolding and revamp task views

### DIFF
--- a/src/lib/projectInfo.ts
+++ b/src/lib/projectInfo.ts
@@ -1,5 +1,10 @@
 import type { ProjectInfo, User } from '../types'
 
+export type ProjectInfoDraftDefaults = {
+  startDate?: string
+  proposedCompletionDate?: string
+}
+
 export type ProjectInfoDraft = {
   lineReference: string
   machineSerialNumbers: string
@@ -11,7 +16,11 @@ export type ProjectInfoDraft = {
   proposedCompletionDate: string
 }
 
-export function createProjectInfoDraft(info: ProjectInfo | undefined, users: User[]): ProjectInfoDraft {
+export function createProjectInfoDraft(
+  info: ProjectInfo | undefined,
+  users: User[],
+  defaults: ProjectInfoDraftDefaults = {},
+): ProjectInfoDraft {
   let salespersonId = info?.salespersonId ?? ''
   if (salespersonId && !users.some(user => user.id === salespersonId)) {
     salespersonId = ''
@@ -33,8 +42,8 @@ export function createProjectInfoDraft(info: ProjectInfo | undefined, users: Use
     cobaltOrderNumber: info?.cobaltOrderNumber ?? '',
     customerOrderNumber: info?.customerOrderNumber ?? '',
     salespersonId,
-    startDate: info?.startDate ?? '',
-    proposedCompletionDate: info?.proposedCompletionDate ?? '',
+    startDate: info?.startDate ?? defaults.startDate ?? '',
+    proposedCompletionDate: info?.proposedCompletionDate ?? defaults.proposedCompletionDate ?? '',
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,59 @@ export type ProjectInfo = {
   proposedCompletionDate?: string;
 };
 
+export const BUSINESS_DAYS = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+] as const;
+
+export type BusinessDay = (typeof BUSINESS_DAYS)[number];
+
+export type BusinessDayHours = {
+  enabled: boolean;
+  start: string; // HH:MM (24h)
+  end: string; // HH:MM (24h)
+};
+
+export type BusinessSettings = {
+  businessName: string;
+  hours: Record<BusinessDay, BusinessDayHours>;
+};
+
+export const DEFAULT_BUSINESS_SETTINGS: BusinessSettings = {
+  businessName: 'Cobalt Systems',
+  hours: {
+    monday: { enabled: true, start: '08:30', end: '17:00' },
+    tuesday: { enabled: true, start: '08:30', end: '17:00' },
+    wednesday: { enabled: true, start: '08:30', end: '17:00' },
+    thursday: { enabled: true, start: '08:30', end: '17:00' },
+    friday: { enabled: true, start: '08:30', end: '17:00' },
+    saturday: { enabled: false, start: '09:00', end: '13:00' },
+    sunday: { enabled: false, start: '09:00', end: '13:00' },
+  },
+};
+
+export type ProjectOnsiteReport = {
+  id: string;
+  reportDate: string;
+  arrivalTime?: string;
+  departureTime?: string;
+  engineerName: string;
+  customerContact?: string;
+  siteAddress?: string;
+  workSummary: string;
+  materialsUsed?: string;
+  additionalNotes?: string;
+  signedByName?: string;
+  signedByPosition?: string;
+  signatureDataUrl?: string;
+  createdAt: string;
+};
+
 export type CustomerSignOffDecision = 'option1' | 'option2' | 'option3';
 
 export const CUSTOMER_SIGN_OFF_DECISIONS: CustomerSignOffDecision[] = ['option1', 'option2', 'option3'];
@@ -123,6 +176,7 @@ export type Project = {
   customerSignOff?: ProjectCustomerSignOff;
   tasks?: ProjectTask[];
   info?: ProjectInfo;
+  onsiteReports?: ProjectOnsiteReport[];
 };
 
 export type CustomerContact = {


### PR DESCRIPTION
## Summary
- add business settings and onsite report structures to shared types and storage persistence
- allow project info drafts to accept prefilled schedule defaults used when creating projects
- redesign the My Tasks page/sidebar with filterable table layout and propagate imported business settings into new project defaults

## Testing
- npm run build *(fails: `vite: Permission denied` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6671534d48321a9dcf1ec4fec057b