### PR TITLE
Add business settings management and improve scheduling UI

### DIFF
--- a/src/components/ui/TaskGanttChart.tsx
+++ b/src/components/ui/TaskGanttChart.tsx
@@ -6,8 +6,20 @@ type TaskWithBounds = {
   end: number
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+function startOfDay(timestamp: number): number {
+  const date = new Date(timestamp)
+  date.setHours(0, 0, 0, 0)
+  return date.getTime()
+}
+
+function addDays(timestamp: number, days: number): number {
+  return timestamp + days * MS_PER_DAY
+}
+
 const STATUS_COLORS: Record<ProjectTaskStatus, string> = {
-  'Not started': 'bg-slate-300',
+  'Not started': 'bg-rose-500',
   Started: 'bg-sky-500',
   Complete: 'bg-emerald-500',
 }
@@ -80,39 +92,80 @@ export default function TaskGanttChart({ tasks }: { tasks: ProjectTask[] }) {
 
   const minStart = entries.reduce((min, entry) => Math.min(min, entry.start), entries[0].start)
   const maxEnd = entries.reduce((max, entry) => Math.max(max, entry.end), entries[0].end)
-  const totalDuration = Math.max(maxEnd - minStart, 1)
+  const calendarStart = startOfDay(minStart)
+  const calendarEnd = addDays(startOfDay(maxEnd), 1)
+  const totalDuration = Math.max(calendarEnd - calendarStart, MS_PER_DAY)
+  const dayCount = Math.max(1, Math.ceil((calendarEnd - calendarStart) / MS_PER_DAY))
+  const days = Array.from({ length: dayCount }, (_, index) => addDays(calendarStart, index))
+  const gridTemplateStyle = { gridTemplateColumns: `repeat(${dayCount}, minmax(0, 1fr))` }
 
   return (
-    <div className='space-y-3'>
+    <div className='space-y-4'>
+      <div className='overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm'>
+        <div
+          className='grid border-b border-slate-200 bg-slate-50 text-xs font-semibold uppercase tracking-wide text-slate-500'
+          style={gridTemplateStyle}
+        >
+          {days.map(day => {
+            const date = new Date(day)
+            const weekdayLabel = date.toLocaleDateString(undefined, { weekday: 'short' })
+            const dateLabel = date.toLocaleDateString(undefined, { day: 'numeric', month: 'short' })
+            return (
+              <div key={day} className='border-r border-slate-200 px-3 py-2 last:border-r-0'>
+                <div>{weekdayLabel}</div>
+                <div className='text-[11px] font-normal text-slate-400'>{dateLabel}</div>
+              </div>
+            )
+          })}
+        </div>
+        <div className='space-y-4 px-4 py-4'>
+          {entries.map(entry => {
+            const clampedStart = Math.max(entry.start, calendarStart)
+            const rawEnd = Math.min(entry.end, calendarEnd)
+            const clampedEnd = Math.max(rawEnd, clampedStart + 1)
+            const startOffset = ((clampedStart - calendarStart) / totalDuration) * 100
+            const widthPercent = ((clampedEnd - clampedStart) / totalDuration) * 100
+            const left = Math.min(Math.max(startOffset, 0), 100)
+            const width = Math.max(Math.min(widthPercent, 100 - left), 1)
+            const colorClass = STATUS_COLORS[entry.task.status] ?? STATUS_COLORS['Not started']
+
+            return (
+              <div key={entry.task.id} className='space-y-2'>
+                <div className='flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500'>
+                  <span className='font-medium text-slate-700'>{entry.task.name}</span>
+                  <span>{formatTimestampRange(entry.task)}</span>
+                </div>
+                <div className='relative overflow-hidden rounded-xl border border-slate-200 bg-slate-50'>
+                  <div
+                    className='pointer-events-none absolute inset-0 grid'
+                    style={gridTemplateStyle}
+                  >
+                    {days.map((day, index) => (
+                      <div
+                        key={day}
+                        className={`border-r border-slate-200/80 ${
+                          index % 2 === 0 ? 'bg-white' : 'bg-slate-50'
+                        } last:border-r-0`}
+                      />
+                    ))}
+                  </div>
+                  <div className='relative h-14 px-2 py-2'>
+                    <div
+                      className={`absolute top-2 bottom-2 rounded-lg ${colorClass}`}
+                      style={{ left: `${left}%`, width: `${width}%` }}
+                    />
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
       <div className='flex justify-between text-xs text-slate-500'>
         <span>{formatAxisLabel(minStart)}</span>
         <span>{formatAxisLabel(maxEnd)}</span>
       </div>
-      <div className='space-y-3'>
-        {entries.map(entry => {
-          const duration = Math.max(entry.end - entry.start, 1)
-          const startOffset = ((entry.start - minStart) / totalDuration) * 100
-          const widthPercent = (duration / totalDuration) * 100
-          const left = Math.min(Math.max(startOffset, 0), 100)
-          const width = Math.max(Math.min(widthPercent, 100 - left), 1)
-          const colorClass = STATUS_COLORS[entry.task.status] ?? STATUS_COLORS['Not started']
-
-          return (
-            <div key={entry.task.id} className='space-y-1'>
-              <div className='flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500'>
-                <span className='font-medium text-slate-700'>{entry.task.name}</span>
-                <span>{formatTimestampRange(entry.task)}</span>
-              </div>
-              <div className='relative h-2.5 rounded-full bg-slate-100'>
-                <div
-                  className={`absolute top-0 h-2.5 rounded-full ${colorClass}`}
-                  style={{ left: `${left}%`, width: `${width}%` }}
-                />
-              </div>
-            </div>
-          )
-        })}
-      </div>
     </div>
   )
+
 }


### PR DESCRIPTION
## Summary
- add a business settings form that lets admins edit the workspace name and daily operating hours for scheduling
- default new project and task dates to the configured working hours and restyle customer/project lists to use a table layout
- refresh the task gantt chart with a calendar-inspired timeline and updated status colours

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da320533b083219bfe895d4b75ab19