### PR TITLE
Add onsite report workflow and update project page UI

### DIFF
--- a/src/lib/onsiteReport.ts
+++ b/src/lib/onsiteReport.ts
@@ -1,0 +1,21 @@
+import type {
+  CustomerSignOffSignatureDimensions,
+  CustomerSignOffSignatureStroke,
+} from '../types'
+
+export type OnsiteReportSubmission = {
+  reportDate: string
+  arrivalTime?: string
+  departureTime?: string
+  engineerName: string
+  customerContact?: string
+  siteAddress?: string
+  workSummary: string
+  materialsUsed?: string
+  additionalNotes?: string
+  signedByName: string
+  signedByPosition?: string
+  signatureDataUrl: string
+  signaturePaths: CustomerSignOffSignatureStroke[]
+  signatureDimensions: CustomerSignOffSignatureDimensions
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -909,6 +909,7 @@ function createLocalStorageStorage(): StorageApi {
     const signedByName = toOptionalString((raw as { signedByName?: unknown }).signedByName)
     const signedByPosition = toOptionalString((raw as { signedByPosition?: unknown }).signedByPosition)
     const signatureDataUrl = toOptionalString((raw as { signatureDataUrl?: unknown }).signatureDataUrl)
+    const pdfDataUrl = toOptionalString((raw as { pdfDataUrl?: unknown }).pdfDataUrl)
     const createdAtRaw = typeof raw.createdAt === 'string' ? raw.createdAt : null
     const createdAt =
       createdAtRaw && !Number.isNaN(Date.parse(createdAtRaw))
@@ -929,6 +930,7 @@ function createLocalStorageStorage(): StorageApi {
       signedByName,
       signedByPosition,
       signatureDataUrl,
+      pdfDataUrl,
       createdAt,
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,7 @@ export type ProjectOnsiteReport = {
   signedByName?: string;
   signedByPosition?: string;
   signatureDataUrl?: string;
+  pdfDataUrl?: string;
   createdAt: string;
 };
 


### PR DESCRIPTION
## Summary
- combine project info editing with the note dialog and refresh the project page layout
- add per-category tabs for project files and expose onsite report management UI
- implement onsite report creation, storage, and PDF generation logic shared between app and storage layers

## Testing
- npm run test
- node node_modules/vite/bin/vite.js build

------
https://chatgpt.com/codex/tasks/task_e_68da38f3599c8321b3c4e52498e10440