### PR TITLE
Add support for customer sites and sub customers

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,21 @@ export type Project = {
   onsiteReports?: ProjectOnsiteReport[];
 };
 
+export type CustomerSite = {
+  id: string;
+  name?: string;
+  address?: string;
+  notes?: string;
+};
+
+export type CustomerSubCustomer = {
+  id: string;
+  name: string;
+  address?: string;
+  notes?: string;
+  siteId?: string;
+};
+
 export type CustomerContact = {
   id: string;
   name?: string;
@@ -192,6 +207,8 @@ export type Customer = {
   id: string;
   name: string;
   address?: string;
+  sites: CustomerSite[];
+  subCustomers: CustomerSubCustomer[];
   contacts: CustomerContact[];
   projects: Project[];
 };


### PR DESCRIPTION
## Summary
- extend the customer schema with reusable site and sub-customer records in shared types and storage normalization
- add UI controls in the customer create/edit flows to manage site locations and sub customers alongside contact details
- surface site and sub-customer information in customer search and detail views so related addresses are visible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da664ded948321bc36d3035e8d4dfc