### PR TITLE
Support parent customer relationships

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -188,14 +188,6 @@ export type CustomerSite = {
   notes?: string;
 };
 
-export type CustomerSubCustomer = {
-  id: string;
-  name: string;
-  address?: string;
-  notes?: string;
-  siteId?: string;
-};
-
 export type CustomerContact = {
   id: string;
   name?: string;
@@ -209,8 +201,8 @@ export type Customer = {
   id: string;
   name: string;
   address?: string;
+  parentCustomerId?: string;
   sites: CustomerSite[];
-  subCustomers: CustomerSubCustomer[];
   contacts: CustomerContact[];
   projects: Project[];
 };


### PR DESCRIPTION
## Summary
- add a parentCustomerId field to customers to track parent-child relationships
- migrate local storage to persist parent associations and convert legacy embedded sub customers
- update the UI to select a parent when creating or editing a customer, show parent details, and list child customers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbdc97355c8321a3962a870799762a