### PR TITLE
feat: open project modal with serial number list

### DIFF
--- a/src/app/ProjectPage.tsx
+++ b/src/app/ProjectPage.tsx
@@ -43,6 +43,7 @@ import {
 import Button from '../components/ui/Button'
 import Input from '../components/ui/Input'
 import Label from '../components/ui/Label'
+import SerialNumberListInput from '../components/ui/SerialNumberListInput'
 import { Card, CardContent, CardHeader } from '../components/ui/Card'
 import { CUSTOMER_SIGN_OFF_OPTIONS, CUSTOMER_SIGN_OFF_OPTION_COPY } from '../lib/signOff'
 import TaskGanttChart from '../components/ui/TaskGanttChart'
@@ -844,7 +845,7 @@ export default function ProjectPage({
     })
   }
 
-  const updateInfoField = (field: keyof ProjectInfoDraft, value: string) => {
+  const updateInfoField = <K extends keyof ProjectInfoDraft>(field: K, value: ProjectInfoDraft[K]) => {
     setInfoDraft(prev => ({ ...prev, [field]: value }))
     if (infoError) {
       setInfoError(null)
@@ -3176,13 +3177,13 @@ export default function ProjectPage({
             onClick={closeNoteDialog}
           >
             <motion.div
-              className='w-full max-w-lg'
+              className='w-full max-w-3xl'
               initial={{ scale: 0.96, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
               exit={{ scale: 0.96, opacity: 0 }}
               onClick={(event) => event.stopPropagation()}
             >
-              <Card className='panel'>
+              <Card className='panel flex max-h-[90vh] flex-col overflow-hidden'>
                 <CardHeader className='flex items-center justify-between'>
                   <div className='flex items-center gap-2'>
                     <Pencil size={18} />
@@ -3192,7 +3193,7 @@ export default function ProjectPage({
                     <X size={16} />
                   </Button>
                 </CardHeader>
-                <CardContent>
+                <CardContent className='max-h-full overflow-y-auto pr-1'>
                   <div className='space-y-6'>
                     <div>
                       <Label>Project note</Label>
@@ -3240,34 +3241,24 @@ export default function ProjectPage({
                             ))}
                           </select>
                         </div>
-                        <div className='md:col-span-2'>
-                          <Label htmlFor='info-machine-serials'>Machine Serial Numbers</Label>
-                          <textarea
-                            id='info-machine-serials'
-                            className='mt-1 w-full resize-y rounded-xl border border-slate-200/80 bg-white/90 p-3 text-sm text-slate-800 placeholder-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100 disabled:cursor-not-allowed disabled:bg-slate-100/70'
-                            rows={3}
-                            value={infoDraft.machineSerialNumbers}
-                            onChange={event =>
-                              updateInfoField('machineSerialNumbers', (event.target as HTMLTextAreaElement).value)
-                            }
-                            placeholder='Enter each serial number on a new line'
-                            disabled={!canEdit || isSavingInfo}
-                          />
-                        </div>
-                        <div className='md:col-span-2'>
-                          <Label htmlFor='info-tool-serials'>Tool Serial Numbers</Label>
-                          <textarea
-                            id='info-tool-serials'
-                            className='mt-1 w-full resize-y rounded-xl border border-slate-200/80 bg-white/90 p-3 text-sm text-slate-800 placeholder-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100 disabled:cursor-not-allowed disabled:bg-slate-100/70'
-                            rows={3}
-                            value={infoDraft.toolSerialNumbers}
-                            onChange={event =>
-                              updateInfoField('toolSerialNumbers', (event.target as HTMLTextAreaElement).value)
-                            }
-                            placeholder='Enter each serial number on a new line'
-                            disabled={!canEdit || isSavingInfo}
-                          />
-                        </div>
+                        <SerialNumberListInput
+                          id='info-machine-serials'
+                          label='Machine Serial Numbers'
+                          values={infoDraft.machineSerialNumbers}
+                          onChange={values => updateInfoField('machineSerialNumbers', values)}
+                          placeholder='e.g. SN-001234'
+                          disabled={!canEdit || isSavingInfo}
+                          className='md:col-span-2'
+                        />
+                        <SerialNumberListInput
+                          id='info-tool-serials'
+                          label='Tool Serial Numbers'
+                          values={infoDraft.toolSerialNumbers}
+                          onChange={values => updateInfoField('toolSerialNumbers', values)}
+                          placeholder='e.g. TOOL-045'
+                          disabled={!canEdit || isSavingInfo}
+                          className='md:col-span-2'
+                        />
                         <div>
                           <Label htmlFor='info-cobalt-order'>Cobalt Order Number</Label>
                           <Input

--- a/src/components/ui/SerialNumberListInput.tsx
+++ b/src/components/ui/SerialNumberListInput.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useState } from 'react'
+import { Plus, X } from 'lucide-react'
+
+import Button from './Button'
+import Input from './Input'
+import Label from './Label'
+
+type SerialNumberListInputProps = {
+  id: string
+  label: string
+  values: string[]
+  onChange: (values: string[]) => void
+  disabled?: boolean
+  placeholder?: string
+  className?: string
+}
+
+export default function SerialNumberListInput({
+  id,
+  label,
+  values,
+  onChange,
+  disabled = false,
+  placeholder,
+  className = '',
+}: SerialNumberListInputProps) {
+  const [inputValue, setInputValue] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleAdd = useCallback(() => {
+    const trimmed = inputValue.trim()
+    if (!trimmed) {
+      setError('Enter a serial number before adding it.')
+      return
+    }
+
+    const exists = values.some(entry => entry.toLowerCase() === trimmed.toLowerCase())
+    if (exists) {
+      setError('This serial number has already been added.')
+      return
+    }
+
+    onChange([...values, trimmed])
+    setInputValue('')
+    setError(null)
+  }, [inputValue, onChange, values])
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      const next = values.filter((_, idx) => idx !== index)
+      onChange(next)
+      setError(null)
+    },
+    [onChange, values],
+  )
+
+  return (
+    <div className={className}>
+      <Label htmlFor={`${id}-input`}>{label}</Label>
+      <div className='mt-1 flex flex-col gap-2 sm:flex-row'>
+        <Input
+          id={`${id}-input`}
+          value={inputValue}
+          onChange={event => {
+            setInputValue((event.target as HTMLInputElement).value)
+            if (error) {
+              setError(null)
+            }
+          }}
+          onKeyDown={event => {
+            if (event.key === 'Enter') {
+              event.preventDefault()
+              if (!disabled) {
+                handleAdd()
+              }
+            }
+          }}
+          placeholder={placeholder}
+          disabled={disabled}
+        />
+        <Button
+          onClick={handleAdd}
+          disabled={disabled}
+          title={disabled ? 'Read-only access' : 'Add serial number'}
+        >
+          <Plus size={16} /> Add
+        </Button>
+      </div>
+      {error && <p className='mt-2 text-xs text-rose-600'>{error}</p>}
+      <div className='mt-3 space-y-2'>
+        {values.length === 0 ? (
+          <p className='text-xs text-slate-500'>No serial numbers added.</p>
+        ) : (
+          <ul className='flex flex-wrap gap-2'>
+            {values.map((serial, index) => (
+              <li
+                key={`${serial}-${index}`}
+                className='flex items-center gap-2 rounded-full border border-slate-200/80 bg-white/90 px-3 py-1 text-sm text-slate-700 shadow-sm'
+              >
+                <span className='font-medium text-slate-700'>{serial}</span>
+                <button
+                  type='button'
+                  className='inline-flex items-center justify-center rounded-full border border-transparent p-1 text-slate-400 transition hover:border-slate-200 hover:bg-slate-100 hover:text-slate-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 disabled:cursor-not-allowed disabled:opacity-60'
+                  onClick={() => handleRemove(index)}
+                  disabled={disabled}
+                  title={disabled ? 'Read-only access' : 'Remove serial number'}
+                >
+                  <X size={14} />
+                  <span className='sr-only'>Remove serial number</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/projectInfo.ts
+++ b/src/lib/projectInfo.ts
@@ -7,8 +7,8 @@ export type ProjectInfoDraftDefaults = {
 
 export type ProjectInfoDraft = {
   lineReference: string
-  machineSerialNumbers: string
-  toolSerialNumbers: string
+  machineSerialNumbers: string[]
+  toolSerialNumbers: string[]
   cobaltOrderNumber: string
   customerOrderNumber: string
   salespersonId: string
@@ -37,8 +37,8 @@ export function createProjectInfoDraft(
 
   return {
     lineReference: info?.lineReference ?? '',
-    machineSerialNumbers: info?.machineSerialNumbers?.join('\n') ?? '',
-    toolSerialNumbers: info?.toolSerialNumbers?.join('\n') ?? '',
+    machineSerialNumbers: info?.machineSerialNumbers ? [...info.machineSerialNumbers] : [],
+    toolSerialNumbers: info?.toolSerialNumbers ? [...info.toolSerialNumbers] : [],
     cobaltOrderNumber: info?.cobaltOrderNumber ?? '',
     customerOrderNumber: info?.customerOrderNumber ?? '',
     salespersonId,
@@ -53,11 +53,9 @@ export function parseProjectInfoDraft(
 ): { info: ProjectInfo | null; error?: string } {
   const lineReference = draft.lineReference.trim()
   const machineSerialNumbers = draft.machineSerialNumbers
-    .split(/\r?\n/)
     .map(entry => entry.trim())
     .filter(entry => entry.length > 0)
   const toolSerialNumbers = draft.toolSerialNumbers
-    .split(/\r?\n/)
     .map(entry => entry.trim())
     .filter(entry => entry.length > 0)
   const cobaltOrderNumber = draft.cobaltOrderNumber.trim()


### PR DESCRIPTION
## Summary
- allow the Add Project button to open the full modal with project info defaults for the active customer and site
- refactor machine and tool serial number inputs into a reusable list component used in project creation and editing
- store project info serial numbers as arrays and make the project info modal scrollable to handle longer forms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de2bd1c0a483219bbf6cce01e817f8