### PR TITLE
Improve customer site defaults and logo sizing

### DIFF
--- a/src/app/ProjectPage.tsx
+++ b/src/app/ProjectPage.tsx
@@ -519,20 +519,25 @@ export default function ProjectPage({
   const buildDefaultOnsiteReportDraft = useCallback((): OnsiteReportDraft => {
     const now = new Date()
     const local = new Date(now.getTime() - now.getTimezoneOffset() * 60000)
+    const projectSite = project.siteId ? customer.sites.find(site => site.id === project.siteId) ?? null : null
+    const fallbackSite = customer.sites.find(site => site.address?.trim()) ?? null
+    const preferredAddress =
+      projectSite?.address?.trim() || fallbackSite?.address?.trim() || customer.address || ''
+
     return {
       reportDate: local.toISOString().slice(0, 10),
       arrivalTime: '',
       departureTime: '',
       engineerName: currentUserDisplayName,
       customerContact: customer.contacts[0]?.name ?? '',
-      siteAddress: customer.address ?? '',
+      siteAddress: preferredAddress,
       workSummary: '',
       materialsUsed: '',
       additionalNotes: '',
       signedByName: '',
       signedByPosition: '',
     }
-  }, [currentUserDisplayName, customer.address, customer.contacts])
+  }, [currentUserDisplayName, customer.address, customer.contacts, customer.sites, project.siteId])
 
   const [onsiteReportDraft, setOnsiteReportDraft] = useState<OnsiteReportDraft>(() =>
     buildDefaultOnsiteReportDraft(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,9 +82,17 @@ export type BusinessDayHours = {
   end: string; // HH:MM (24h)
 };
 
+export type BusinessLogo = {
+  dataUrl: string;
+  width: number;
+  height: number;
+  mimeType: 'image/png' | 'image/jpeg';
+};
+
 export type BusinessSettings = {
   businessName: string;
   hours: Record<BusinessDay, BusinessDayHours>;
+  logo: BusinessLogo | null;
 };
 
 export const DEFAULT_BUSINESS_SETTINGS: BusinessSettings = {
@@ -98,6 +106,7 @@ export const DEFAULT_BUSINESS_SETTINGS: BusinessSettings = {
     saturday: { enabled: false, start: '09:00', end: '13:00' },
     sunday: { enabled: false, start: '09:00', end: '13:00' },
   },
+  logo: null,
 };
 
 export type ProjectOnsiteReport = {


### PR DESCRIPTION
## Summary
- default customer detail pages to the first site with an address to align with the primary location requirement
- adjust navigation logo rendering so uploaded business artwork displays consistently under the workspace name
- reuse shared logo dimension constraints when embedding artwork in generated PDFs so documents match the navigation sizing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de5990cc608321a6a3c7c9ed4d4e14