### PR TITLE
Support machine-to-tool associations and customer lines view

### DIFF
--- a/src/app/ProjectPage.tsx
+++ b/src/app/ProjectPage.tsx
@@ -43,7 +43,7 @@ import {
 import Button from '../components/ui/Button'
 import Input from '../components/ui/Input'
 import Label from '../components/ui/Label'
-import SerialNumberListInput from '../components/ui/SerialNumberListInput'
+import MachineToolListInput from '../components/ui/MachineToolListInput'
 import { Card, CardContent, CardHeader } from '../components/ui/Card'
 import { CUSTOMER_SIGN_OFF_OPTIONS, CUSTOMER_SIGN_OFF_OPTION_COPY } from '../lib/signOff'
 import TaskGanttChart from '../components/ui/TaskGanttChart'
@@ -2273,8 +2273,7 @@ export default function ProjectPage({
 
   const renderProjectInfo = () => {
     const info = project.info
-    const machineSerialNumbers = info?.machineSerialNumbers ?? []
-    const toolSerialNumbers = info?.toolSerialNumbers ?? []
+    const machines = info?.machines ?? []
     const salespersonName = info?.salespersonId
       ? users.find(user => user.id === info.salespersonId)?.name ?? info.salespersonName ?? null
       : info?.salespersonName ?? null
@@ -2340,37 +2339,43 @@ export default function ProjectPage({
                   </dl>
                 </div>
               </div>
-              <div className='grid gap-4 md:grid-cols-2'>
-                <div>
-                  <div className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Machine serial numbers</div>
-                  {machineSerialNumbers.length > 0 ? (
-                    <ul className='mt-2 space-y-1 text-xs text-slate-600'>
-                      {machineSerialNumbers.map((serial, index) => (
-                        <li key={`${serial}-${index}`} className='flex items-center gap-2'>
-                          <span className='h-1.5 w-1.5 rounded-full bg-slate-400' aria-hidden />
-                          <span>{serial}</span>
+              <div>
+                <div className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Machines &amp; tools</div>
+                {machines.length > 0 ? (
+                  <ul className='mt-2 space-y-3 text-xs text-slate-600'>
+                    {machines.map((machine, index) => {
+                      const label = machine.machineSerialNumber.trim() || 'Not specified'
+                      return (
+                        <li
+                          key={`${machine.machineSerialNumber || 'machine'}-${index}`}
+                          className='space-y-2 rounded-xl border border-slate-200/80 bg-white/90 p-3 shadow-sm'
+                        >
+                          <div className='flex items-center justify-between gap-2 text-sm font-semibold text-slate-700'>
+                            <span>Machine: {label}</span>
+                            <span className='text-xs font-medium text-slate-500'>
+                              {machine.toolSerialNumbers.length}{' '}
+                              {machine.toolSerialNumbers.length === 1 ? 'tool' : 'tools'}
+                            </span>
+                          </div>
+                          {machine.toolSerialNumbers.length > 0 ? (
+                            <ul className='space-y-1'>
+                              {machine.toolSerialNumbers.map((serial, toolIndex) => (
+                                <li key={`${serial}-${toolIndex}`} className='flex items-center gap-2'>
+                                  <span className='h-1.5 w-1.5 rounded-full bg-slate-400' aria-hidden />
+                                  <span>{serial}</span>
+                                </li>
+                              ))}
+                            </ul>
+                          ) : (
+                            <p className='text-xs text-slate-400'>No tool serial numbers recorded.</p>
+                          )}
                         </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p className='mt-2 text-xs text-slate-400'>No machine serial numbers recorded.</p>
-                  )}
-                </div>
-                <div>
-                  <div className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Tool serial numbers</div>
-                  {toolSerialNumbers.length > 0 ? (
-                    <ul className='mt-2 space-y-1 text-xs text-slate-600'>
-                      {toolSerialNumbers.map((serial, index) => (
-                        <li key={`${serial}-${index}`} className='flex items-center gap-2'>
-                          <span className='h-1.5 w-1.5 rounded-full bg-slate-400' aria-hidden />
-                          <span>{serial}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p className='mt-2 text-xs text-slate-400'>No tool serial numbers recorded.</p>
-                  )}
-                </div>
+                      )
+                    })}
+                  </ul>
+                ) : (
+                  <p className='mt-2 text-xs text-slate-400'>No machines recorded.</p>
+                )}
               </div>
             </div>
           ) : (
@@ -3246,21 +3251,10 @@ export default function ProjectPage({
                             ))}
                           </select>
                         </div>
-                        <SerialNumberListInput
-                          id='info-machine-serials'
-                          label='Machine Serial Numbers'
-                          values={infoDraft.machineSerialNumbers}
-                          onChange={values => updateInfoField('machineSerialNumbers', values)}
-                          placeholder='e.g. SN-001234'
-                          disabled={!canEdit || isSavingInfo}
-                          className='md:col-span-2'
-                        />
-                        <SerialNumberListInput
-                          id='info-tool-serials'
-                          label='Tool Serial Numbers'
-                          values={infoDraft.toolSerialNumbers}
-                          onChange={values => updateInfoField('toolSerialNumbers', values)}
-                          placeholder='e.g. TOOL-045'
+                        <MachineToolListInput
+                          id='info-machines'
+                          machines={infoDraft.machines}
+                          onChange={machines => updateInfoField('machines', machines)}
                           disabled={!canEdit || isSavingInfo}
                           className='md:col-span-2'
                         />

--- a/src/components/ui/MachineToolListInput.tsx
+++ b/src/components/ui/MachineToolListInput.tsx
@@ -1,0 +1,142 @@
+import { useCallback } from 'react'
+import { Plus, Trash2 } from 'lucide-react'
+
+import { createId } from '../../lib/id'
+import type { ProjectMachineDraft } from '../../lib/projectInfo'
+import Button from './Button'
+import Input from './Input'
+import Label from './Label'
+import SerialNumberListInput from './SerialNumberListInput'
+
+type MachineToolListInputProps = {
+  id: string
+  machines: ProjectMachineDraft[]
+  onChange: (machines: ProjectMachineDraft[]) => void
+  disabled?: boolean
+  className?: string
+}
+
+export default function MachineToolListInput({
+  id,
+  machines,
+  onChange,
+  disabled = false,
+  className = '',
+}: MachineToolListInputProps) {
+  const handleAddMachine = useCallback(() => {
+    if (disabled) {
+      return
+    }
+    onChange([
+      ...machines,
+      { id: createId(), machineSerialNumber: '', toolSerialNumbers: [] },
+    ])
+  }, [disabled, machines, onChange])
+
+  const updateMachine = useCallback(
+    (machineId: string, updates: Partial<ProjectMachineDraft>) => {
+      onChange(
+        machines.map(machine =>
+          machine.id === machineId ? { ...machine, ...updates, id: machine.id } : machine,
+        ),
+      )
+    },
+    [machines, onChange],
+  )
+
+  const handleRemoveMachine = useCallback(
+    (machineId: string) => {
+      if (disabled) {
+        return
+      }
+      onChange(machines.filter(machine => machine.id !== machineId))
+    },
+    [disabled, machines, onChange],
+  )
+
+  return (
+    <div className={className}>
+      <div className='flex flex-wrap items-center justify-between gap-2'>
+        <Label htmlFor={`${id}-add`}>Machines &amp; Tools</Label>
+        <Button
+          id={`${id}-add`}
+          type='button'
+          variant='outline'
+          onClick={handleAddMachine}
+          disabled={disabled}
+          title={disabled ? 'Read-only access' : 'Add machine'}
+        >
+          <Plus size={16} /> Add Machine
+        </Button>
+      </div>
+      <div className='mt-3 space-y-3'>
+        {machines.length === 0 ? (
+          <p className='text-xs text-slate-500'>No machines recorded.</p>
+        ) : (
+          machines.map((machine, index) => {
+            const machineId = machine.id
+            const machineInputId = `${id}-machine-${machineId}`
+            const toolsInputId = `${id}-tools-${machineId}`
+            const machineLabel = `Machine ${index + 1}`
+            const hasMachineSerial = machine.machineSerialNumber.trim().length > 0
+            return (
+              <div
+                key={machineId}
+                className='space-y-3 rounded-2xl border border-slate-200/80 bg-white/90 p-4 shadow-sm'
+              >
+                <div className='flex flex-wrap items-start gap-3'>
+                  <div className='min-w-[200px] flex-1'>
+                    <Label htmlFor={machineInputId}>{machineLabel}</Label>
+                    <Input
+                      id={machineInputId}
+                      value={machine.machineSerialNumber}
+                      onChange={event =>
+                        updateMachine(machineId, {
+                          machineSerialNumber: (event.target as HTMLInputElement).value,
+                        })
+                      }
+                      placeholder='e.g. SN-001234'
+                      disabled={disabled}
+                    />
+                  </div>
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    onClick={() => handleRemoveMachine(machineId)}
+                    disabled={disabled}
+                    title={disabled ? 'Read-only access' : 'Remove machine'}
+                    className='rounded-full px-3 py-1 text-sm text-rose-600 hover:bg-rose-50 disabled:text-slate-400'
+                  >
+                    <Trash2 size={16} /> Remove
+                  </Button>
+                </div>
+                <div>
+                  <SerialNumberListInput
+                    id={toolsInputId}
+                    label='Tool Serial Numbers'
+                    values={machine.toolSerialNumbers}
+                    onChange={values =>
+                      updateMachine(machineId, { toolSerialNumbers: values })
+                    }
+                    placeholder='e.g. TOOL-045'
+                    disabled={disabled}
+                    validateAdd={(_serial, _existing) =>
+                      hasMachineSerial
+                        ? null
+                        : 'Enter the machine serial number before adding tools.'
+                    }
+                  />
+                  {!hasMachineSerial && machine.toolSerialNumbers.length === 0 ? (
+                    <p className='mt-2 text-xs text-slate-500'>
+                      Enter a machine serial number before adding tool serial numbers.
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/SerialNumberListInput.tsx
+++ b/src/components/ui/SerialNumberListInput.tsx
@@ -13,6 +13,7 @@ type SerialNumberListInputProps = {
   disabled?: boolean
   placeholder?: string
   className?: string
+  validateAdd?: (serial: string, existing: string[]) => string | null
 }
 
 export default function SerialNumberListInput({
@@ -23,6 +24,7 @@ export default function SerialNumberListInput({
   disabled = false,
   placeholder,
   className = '',
+  validateAdd,
 }: SerialNumberListInputProps) {
   const [inputValue, setInputValue] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -40,10 +42,18 @@ export default function SerialNumberListInput({
       return
     }
 
+    if (validateAdd) {
+      const validationError = validateAdd(trimmed, values)
+      if (validationError) {
+        setError(validationError)
+        return
+      }
+    }
+
     onChange([...values, trimmed])
     setInputValue('')
     setError(null)
-  }, [inputValue, onChange, values])
+  }, [inputValue, onChange, validateAdd, values])
 
   const handleRemove = useCallback(
     (index: number) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,10 +52,14 @@ export type ProjectStatusLogEntry = {
   changedBy: string;
 };
 
+export type ProjectMachine = {
+  machineSerialNumber: string;
+  toolSerialNumbers: string[];
+};
+
 export type ProjectInfo = {
   lineReference?: string;
-  machineSerialNumbers?: string[];
-  toolSerialNumbers?: string[];
+  machines?: ProjectMachine[];
   cobaltOrderNumber?: string;
   customerOrderNumber?: string;
   salespersonId?: string;


### PR DESCRIPTION
## Summary
- model machine serials with their associated tool serial numbers throughout the app and PDFs
- add a machine/tool editor component and update project info forms and displays
- extend the customer detail view with a Lines tab that aggregates machines and offers an Add Machine entry point

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de624db8148321b4fbda7137f378dc