### PR TITLE
Add machine modal and move line references to machines

### DIFF
--- a/src/app/ProjectPage.tsx
+++ b/src/app/ProjectPage.tsx
@@ -2296,12 +2296,6 @@ export default function ProjectPage({
                   <div className='text-xs font-semibold uppercase tracking-wide text-slate-500'>General</div>
                   <dl className='mt-2 space-y-1 text-sm text-slate-700'>
                     <div className='flex justify-between gap-3'>
-                      <dt className='text-slate-500'>Line No/Name</dt>
-                      <dd className='text-right font-medium text-slate-800'>
-                        {info?.lineReference ?? '—'}
-                      </dd>
-                    </div>
-                    <div className='flex justify-between gap-3'>
                       <dt className='text-slate-500'>Cobalt Order #</dt>
                       <dd className='text-right font-medium text-slate-800'>
                         {info?.cobaltOrderNumber ?? '—'}
@@ -2357,6 +2351,9 @@ export default function ProjectPage({
                               {machine.toolSerialNumbers.length === 1 ? 'tool' : 'tools'}
                             </span>
                           </div>
+                          {machine.lineReference?.trim() ? (
+                            <div className='text-xs text-slate-500'>Line: {machine.lineReference}</div>
+                          ) : null}
                           {machine.toolSerialNumbers.length > 0 ? (
                             <ul className='space-y-1'>
                               {machine.toolSerialNumbers.map((serial, toolIndex) => (
@@ -3222,16 +3219,6 @@ export default function ProjectPage({
                         <p className='text-xs text-slate-500'>Provide project metadata, serial numbers, and sales context.</p>
                       </div>
                       <div className='grid gap-3 md:grid-cols-2'>
-                        <div>
-                          <Label htmlFor='info-line'>Line No/Name</Label>
-                          <Input
-                            id='info-line'
-                            value={infoDraft.lineReference}
-                            onChange={event => updateInfoField('lineReference', (event.target as HTMLInputElement).value)}
-                            placeholder='e.g. Line 3 — Bottling'
-                            disabled={!canEdit || isSavingInfo}
-                          />
-                        </div>
                         <div>
                           <Label htmlFor='info-salesperson'>Salesperson</Label>
                           <select

--- a/src/components/ui/MachineToolListInput.tsx
+++ b/src/components/ui/MachineToolListInput.tsx
@@ -29,7 +29,7 @@ export default function MachineToolListInput({
     }
     onChange([
       ...machines,
-      { id: createId(), machineSerialNumber: '', toolSerialNumbers: [] },
+      { id: createId(), machineSerialNumber: '', lineReference: '', toolSerialNumbers: [] },
     ])
   }, [disabled, machines, onChange])
 
@@ -77,6 +77,7 @@ export default function MachineToolListInput({
             const machineId = machine.id
             const machineInputId = `${id}-machine-${machineId}`
             const toolsInputId = `${id}-tools-${machineId}`
+            const lineInputId = `${id}-line-${machineId}`
             const machineLabel = `Machine ${index + 1}`
             const hasMachineSerial = machine.machineSerialNumber.trim().length > 0
             return (
@@ -98,6 +99,20 @@ export default function MachineToolListInput({
                       placeholder='e.g. SN-001234'
                       disabled={disabled}
                     />
+                    <div className='mt-3'>
+                      <Label htmlFor={lineInputId}>Line No/Name (optional)</Label>
+                      <Input
+                        id={lineInputId}
+                        value={machine.lineReference}
+                        onChange={event =>
+                          updateMachine(machineId, {
+                            lineReference: (event.target as HTMLInputElement).value,
+                          })
+                        }
+                        placeholder='e.g. Line 2 — Packing'
+                        disabled={disabled}
+                      />
+                    </div>
                   </div>
                   <Button
                     type='button'

--- a/src/lib/signOff.ts
+++ b/src/lib/signOff.ts
@@ -40,7 +40,6 @@ export type CustomerSignOffPdfInput = {
   businessLogo?: BusinessLogo | null
   projectNumber: string
   customerName: string
-  lineReference?: string
   machines?: ProjectMachine[]
   machineSerialNumbers?: string[]
   toolSerialNumbers?: string[]
@@ -434,10 +433,20 @@ export async function generateCustomerSignOffPdf(data: CustomerSignOffPdfInput):
         .map(machine => {
           const machineLabel = machine.machineSerialNumber.trim() || 'Not specified'
           const tools = machine.toolSerialNumbers.map(entry => entry.trim()).filter(entry => entry.length > 0)
-          if (tools.length === 0) {
-            return `${machineLabel} — No tools recorded`
+          const details: string[] = []
+          const line = machine.lineReference?.trim()
+          if (line) {
+            details.push(`Line: ${line}`)
           }
-          return `${machineLabel} — Tools: ${tools.join(', ')}`
+          if (tools.length === 0) {
+            details.push('No tools recorded')
+          } else {
+            details.push(`Tools: ${tools.join(', ')}`)
+          }
+          if (details.length === 0) {
+            return machineLabel
+          }
+          return `${machineLabel} — ${details.join(' — ')}`
         })
         .join('\n')
     }
@@ -473,7 +482,6 @@ export async function generateCustomerSignOffPdf(data: CustomerSignOffPdfInput):
   drawLabelValue('Completed', completedDisplay)
 
   drawHeading('Project Information', 16, 16)
-  drawLabelValue('Line No/Name', data.lineReference ?? 'Not provided')
   drawLabelValue('Machines & Tools', formatMachinesAndTools())
   drawLabelValue('Cobalt Order Number', data.cobaltOrderNumber ?? 'Not provided')
   drawLabelValue('Customer Order Number', data.customerOrderNumber ?? 'Not provided')

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,11 +54,11 @@ export type ProjectStatusLogEntry = {
 
 export type ProjectMachine = {
   machineSerialNumber: string;
+  lineReference?: string;
   toolSerialNumbers: string[];
 };
 
 export type ProjectInfo = {
-  lineReference?: string;
   machines?: ProjectMachine[];
   cobaltOrderNumber?: string;
   customerOrderNumber?: string;


### PR DESCRIPTION
## Summary
- remove the legacy head office default and default customer view to the first actual site, adding an unassigned tab when needed
- add a modal to create or edit machines with serial numbers, line references, and tool tracking without leaving the customer page
- migrate line metadata from projects to machines and update storage, PDF output, and project UI accordingly

## Testing
- npm run build *(fails: vite: Permission denied in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de6bf18eec8321925385e15fef306c