### PR TITLE
Surface parent-linked projects under sub-customer site tabs

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,8 @@ export type Project = {
   activeSubStatus?: ProjectActiveSubStatus;
   note?: string; // ⬅️ new
   siteId?: string;
+  linkedSubCustomerId?: string;
+  linkedSubCustomerSiteId?: string;
   wos: WO[];
   documents?: ProjectDocuments;
   statusHistory?: ProjectStatusLogEntry[];


### PR DESCRIPTION
## Summary
- update the customer site tab generation so sub-customer views consider parent-linked projects when determining the unassigned tab
- aggregate parent-associated projects into the site/project lookup so linked parent work shows up alongside the sub-customer's own records

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de83be2ba48321b1712b4e2ae380a6