### PR TITLE
Revamp customer tabs and machine ownership flows

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -7,7 +9,7 @@
 }
 
 body {
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background:
     radial-gradient(circle at top right, rgba(56, 189, 248, 0.12), transparent 55%),
     radial-gradient(circle at 10% 15%, rgba(199, 210, 254, 0.16), transparent 45%),

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,15 @@ export type ProjectMachine = {
   toolSerialNumbers: string[];
 };
 
+export type CustomerMachine = {
+  id: string;
+  machineSerialNumber: string;
+  lineReference?: string;
+  toolSerialNumbers: string[];
+  siteId?: string;
+  projectId?: string;
+};
+
 export type ProjectInfo = {
   machines?: ProjectMachine[];
   cobaltOrderNumber?: string;
@@ -220,6 +229,7 @@ export type Customer = {
   sites: CustomerSite[];
   contacts: CustomerContact[];
   projects: Project[];
+  machines: CustomerMachine[];
 };
 
 export type AppRole = 'viewer' | 'editor' | 'admin';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,11 @@
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Montserrat', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- reorder the customer detail tabs to prioritize projects and persistently default to the Projects view
- expand the sub-customer cards with address, map preview, and primary contact information
- support standalone machine records with optional project association for parent or child customers and switch the global font to Montserrat

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de97b2042883218e91ffe5666ef380