### PR TITLE
Enforce unique machine/tool serials and align time pickers with business hours

### DIFF
--- a/src/components/ui/MachineToolListInput.tsx
+++ b/src/components/ui/MachineToolListInput.tsx
@@ -135,11 +135,27 @@ export default function MachineToolListInput({
                     }
                     placeholder='e.g. TOOL-045'
                     disabled={disabled}
-                    validateAdd={(_serial, _existing) =>
-                      hasMachineSerial
-                        ? null
-                        : 'Enter the machine serial number before adding tools.'
-                    }
+                    validateAdd={(serial, existing) => {
+                      if (!hasMachineSerial) {
+                        return 'Enter the machine serial number before adding tools.'
+                      }
+                      if (existing.length >= 1) {
+                        return 'Machines can only have one tool.'
+                      }
+                      const normalized = serial.trim().toLowerCase()
+                      const hasDuplicateTool = machines.some(other => {
+                        if (other.id === machineId) {
+                          return false
+                        }
+                        return other.toolSerialNumbers.some(tool =>
+                          tool.trim().toLowerCase() === normalized,
+                        )
+                      })
+                      if (hasDuplicateTool) {
+                        return 'Tool serial numbers must be unique.'
+                      }
+                      return null
+                    }}
                   />
                   {!hasMachineSerial && machine.toolSerialNumbers.length === 0 ? (
                     <p className='mt-2 text-xs text-slate-500'>

--- a/src/lib/projectInfo.ts
+++ b/src/lib/projectInfo.ts
@@ -113,6 +113,7 @@ export function parseProjectInfoDraft(
 ): { info: ProjectInfo | null; error?: string } {
   const machines: ProjectMachine[] = []
   const seenMachineSerials = new Set<string>()
+  const seenToolSerials = new Set<string>()
   for (const machine of draft.machines) {
     const machineSerialNumber = machine.machineSerialNumber.trim()
     const lineReference = machine.lineReference.trim()
@@ -131,6 +132,10 @@ export function parseProjectInfoDraft(
       normalizedTools.push(trimmed)
     }
 
+    if (normalizedTools.length > 1) {
+      return { info: null, error: 'Machines can only have one tool.' }
+    }
+
     if (!machineSerialNumber) {
       if (normalizedTools.length > 0) {
         return {
@@ -147,6 +152,13 @@ export function parseProjectInfoDraft(
     }
     seenMachineSerials.add(normalizedMachine)
     const machineEntry: ProjectMachine = { machineSerialNumber, toolSerialNumbers: normalizedTools }
+    if (normalizedTools.length === 1) {
+      const normalizedTool = normalizedTools[0].toLowerCase()
+      if (seenToolSerials.has(normalizedTool)) {
+        return { info: null, error: 'Tool serial numbers must be unique.' }
+      }
+      seenToolSerials.add(normalizedTool)
+    }
     if (lineReference) {
       machineEntry.lineReference = lineReference
     }


### PR DESCRIPTION
## Summary
- ensure machine edits enforce a single tool per machine and prevent duplicate tool serials across project and customer machines
- update project info parsing and the machine tool list input to flag extra tools and duplicate serial numbers
- default onsite report times to the business-day start and set all time pickers to 30-minute increments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfade0f68c8321bdfc96e4370745db