### PR TITLE
Add machine detail view and service tracking

### DIFF
--- a/src/app/MachinePage.tsx
+++ b/src/app/MachinePage.tsx
@@ -1,0 +1,250 @@
+import { useMemo } from 'react'
+import { ArrowLeft, Download, MapPin, Pencil, Tag } from 'lucide-react'
+import type { Customer, CustomerMachine, Project, ProjectOnsiteReport } from '../types'
+import Button from '../components/ui/Button'
+import { Card, CardContent, CardHeader } from '../components/ui/Card'
+import Label from '../components/ui/Label'
+
+function formatDateValue(value?: string | null): string {
+  if (!value) {
+    return 'Not specified'
+  }
+  const parsed = Date.parse(value)
+  if (Number.isNaN(parsed)) {
+    return value
+  }
+  return new Date(parsed).toLocaleDateString()
+}
+
+function formatHanding(value?: CustomerMachine['handing']): string {
+  if (!value) {
+    return 'Not specified'
+  }
+  return value === 'left' ? 'Left' : 'Right'
+}
+
+type ServiceHistoryEntry = {
+  project: Project
+  report: ProjectOnsiteReport
+}
+
+type MachinePageProps = {
+  customer: Customer
+  machine: CustomerMachine
+  canEdit: boolean
+  onBack: () => void
+  onEdit: () => void
+  onNavigateToProject: (projectId: string) => void
+}
+
+export default function MachinePage({
+  customer,
+  machine,
+  canEdit,
+  onBack,
+  onEdit,
+  onNavigateToProject,
+}: MachinePageProps) {
+  const site = machine.siteId ? customer.sites.find(entry => entry.id === machine.siteId) ?? null : null
+  const linkedProject = machine.projectId
+    ? customer.projects.find(entry => entry.id === machine.projectId) ?? null
+    : null
+
+  const serviceHistory = useMemo<ServiceHistoryEntry[]>(() => {
+    const entries: ServiceHistoryEntry[] = []
+    for (const project of customer.projects) {
+      const reports = project.onsiteReports ?? []
+      for (const report of reports) {
+        if (report.machineId === machine.id) {
+          entries.push({ project, report })
+        }
+      }
+    }
+    entries.sort((a, b) => {
+      const aDate = a.report.reportDate ? Date.parse(a.report.reportDate) : Date.parse(a.report.createdAt)
+      const bDate = b.report.reportDate ? Date.parse(b.report.reportDate) : Date.parse(b.report.createdAt)
+      if (Number.isNaN(aDate) && Number.isNaN(bDate)) {
+        return 0
+      }
+      if (Number.isNaN(aDate)) {
+        return 1
+      }
+      if (Number.isNaN(bDate)) {
+        return -1
+      }
+      return bDate - aDate
+    })
+    return entries
+  }, [customer.projects, machine.id])
+
+  const handleDownloadReport = (entry: ServiceHistoryEntry) => {
+    const { report, project } = entry
+    if (!report.pdfDataUrl) {
+      window.alert('This onsite report is missing a PDF document.')
+      return
+    }
+    const link = document.createElement('a')
+    const sanitizedNumber = project.number.replace(/[^A-Za-z0-9-]/g, '')
+    const datePart = report.reportDate ? report.reportDate.replace(/[^0-9-]/g, '') : null
+    link.href = report.pdfDataUrl
+    link.download = `OnsiteReport-${sanitizedNumber || project.number}-${datePart || report.id}.pdf`
+    link.rel = 'noopener'
+    link.target = '_blank'
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
+
+  return (
+    <div className='space-y-6'>
+      <div className='flex flex-wrap items-center justify-between gap-3'>
+        <Button variant='ghost' onClick={onBack} className='flex items-center gap-2'>
+          <ArrowLeft size={16} /> Back to customer
+        </Button>
+        <div className='flex items-center gap-2'>
+          {canEdit ? (
+            <Button onClick={onEdit} className='flex items-center gap-2'>
+              <Pencil size={16} /> Edit machine
+            </Button>
+          ) : null}
+        </div>
+      </div>
+      <Card className='panel'>
+        <CardHeader>
+          <div className='flex flex-wrap items-start justify-between gap-3'>
+            <div>
+              <h2 className='text-xl font-semibold text-slate-900'>Machine {machine.machineSerialNumber}</h2>
+              <p className='mt-1 text-sm text-slate-500'>Detailed information and service history.</p>
+            </div>
+            {linkedProject ? (
+              <Button variant='outline' onClick={() => onNavigateToProject(linkedProject.id)}>
+                <Tag size={16} /> View project {linkedProject.number}
+              </Button>
+            ) : null}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className='grid gap-4 md:grid-cols-2'>
+            <div>
+              <Label>Model</Label>
+              <p className='mt-1 text-sm text-slate-700'>{machine.model?.trim() || 'Not specified'}</p>
+            </div>
+            <div>
+              <Label>Make</Label>
+              <p className='mt-1 text-sm text-slate-700'>{machine.make?.trim() || 'Not specified'}</p>
+            </div>
+            <div>
+              <Label>Handing</Label>
+              <p className='mt-1 text-sm text-slate-700'>{formatHanding(machine.handing)}</p>
+            </div>
+            <div>
+              <Label>Firmware version</Label>
+              <p className='mt-1 text-sm text-slate-700'>{machine.firmwareVersion?.trim() || 'Not specified'}</p>
+            </div>
+            <div>
+              <Label>Date installed</Label>
+              <p className='mt-1 text-sm text-slate-700'>{formatDateValue(machine.dateInstalled)}</p>
+            </div>
+            <div>
+              <Label>Date of last service</Label>
+              <p className='mt-1 text-sm text-slate-700'>{formatDateValue(machine.dateLastService)}</p>
+            </div>
+            <div>
+              <Label>Last service count</Label>
+              <p className='mt-1 text-sm text-slate-700'>
+                {typeof machine.lastServiceCount === 'number' ? machine.lastServiceCount : 'Not specified'}
+              </p>
+            </div>
+            <div>
+              <Label>Line reference</Label>
+              <p className='mt-1 text-sm text-slate-700'>{machine.lineReference?.trim() || 'Not specified'}</p>
+            </div>
+          </div>
+          <div className='mt-4 grid gap-3 md:grid-cols-2'>
+            <div>
+              <Label>Site</Label>
+              <p className='mt-1 flex items-center gap-2 text-sm text-slate-700'>
+                <MapPin size={14} className='text-slate-400' />
+                {site
+                  ? site.name?.trim() || site.address?.trim() || 'Unnamed site'
+                  : 'Not assigned to a site'}
+              </p>
+            </div>
+            <div>
+              <Label>Associated project</Label>
+              <p className='mt-1 text-sm text-slate-700'>
+                {linkedProject ? `Project ${linkedProject.number}` : 'No associated project'}
+              </p>
+            </div>
+          </div>
+          <div className='mt-4'>
+            <Label>Notes</Label>
+            <p className='mt-1 whitespace-pre-wrap rounded-2xl border border-slate-200/70 bg-white/80 p-3 text-sm text-slate-700'>
+              {machine.notes?.trim() || 'No additional notes recorded.'}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+      <Card className='panel'>
+        <CardHeader>
+          <div className='flex flex-wrap items-center justify-between gap-3'>
+            <div>
+              <h3 className='text-lg font-semibold text-slate-900'>Service history</h3>
+              <p className='mt-1 text-sm text-slate-500'>Onsite reports linked to this machine.</p>
+            </div>
+            <span className='rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600'>
+              {serviceHistory.length} visits
+            </span>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {serviceHistory.length === 0 ? (
+            <p className='text-sm text-slate-600'>No service visits recorded yet.</p>
+          ) : (
+            <div className='space-y-3'>
+              {serviceHistory.map(entry => {
+                const { report, project } = entry
+                const reportDate = report.reportDate ? formatDateValue(report.reportDate) : formatDateValue(report.createdAt)
+                return (
+                  <div key={report.id} className='rounded-2xl border border-slate-200/70 bg-white/80 p-4 shadow-sm'>
+                    <div className='flex flex-wrap items-start justify-between gap-3'>
+                      <div>
+                        <div className='text-sm font-semibold text-slate-800'>
+                          {project ? `Project ${project.number}` : 'Project removed'}
+                        </div>
+                        <div className='text-xs text-slate-500'>Report date: {reportDate}</div>
+                        <div className='mt-1 text-xs text-slate-500'>Engineer: {report.engineerName || 'Not recorded'}</div>
+                      </div>
+                      <Button
+                        variant='outline'
+                        onClick={() => handleDownloadReport(entry)}
+                        disabled={!report.pdfDataUrl}
+                        title={report.pdfDataUrl ? 'Download onsite report' : 'Report PDF unavailable'}
+                      >
+                        <Download size={16} /> Download
+                      </Button>
+                    </div>
+                    <div className='mt-3 grid gap-3 md:grid-cols-2'>
+                      <div>
+                        <div className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Service details</div>
+                        <p className='mt-1 whitespace-pre-wrap text-sm text-slate-700'>
+                          {report.serviceInformation || report.workSummary || 'No details recorded.'}
+                        </p>
+                      </div>
+                      <div>
+                        <div className='text-xs font-semibold uppercase tracking-wide text-slate-500'>Firmware version</div>
+                        <p className='mt-1 text-sm text-slate-700'>
+                          {report.firmwareVersion || machine.firmwareVersion || 'Not specified.'}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/lib/onsiteReport.ts
+++ b/src/lib/onsiteReport.ts
@@ -18,4 +18,7 @@ export type OnsiteReportSubmission = {
   signatureDataUrl: string
   signaturePaths: CustomerSignOffSignatureStroke[]
   signatureDimensions: CustomerSignOffSignatureDimensions
+  machineId?: string
+  serviceInformation?: string
+  firmwareVersion?: string
 }

--- a/src/lib/signOff.ts
+++ b/src/lib/signOff.ts
@@ -76,6 +76,9 @@ export type OnsiteReportPdfInput = {
   signaturePaths: CustomerSignOffSignatureStroke[]
   signatureDimensions: CustomerSignOffSignatureDimensions
   createdAt: string
+  machineSerialNumber?: string
+  serviceInformation?: string
+  firmwareVersion?: string
 }
 
 const BUSINESS_LOGO_MAX_WIDTH_PT = (240 / 96) * 72
@@ -711,6 +714,11 @@ export async function generateOnsiteReportPdf(data: OnsiteReportPdfInput): Promi
   drawLabelValue('Arrival Time', formatTimeValue(data.arrivalTime))
   drawLabelValue('Departure Time', formatTimeValue(data.departureTime))
   drawLabelValue('Customer Contact', data.customerContact)
+
+  drawHeading('Service Details', 16, 16)
+  drawLabelValue('Machine', data.machineSerialNumber)
+  drawLabelValue('Firmware Version', data.firmwareVersion)
+  drawTextBlock('Service Information', data.serviceInformation)
 
   drawTextBlock('Work Summary', data.workSummary)
   drawTextBlock('Materials Used', data.materialsUsed)

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -4,6 +4,7 @@ import type {
   BusinessSettings,
   Customer,
   CustomerMachine,
+  MachineHanding,
   CustomerSite,
   CustomerContact,
   Project,
@@ -76,6 +77,14 @@ type StorageApi = {
       toolSerialNumbers?: string[]
       siteId?: string | null
       projectId?: string | null
+      model?: string | null
+      make?: string | null
+      handing?: MachineHanding | null
+      dateInstalled?: string | null
+      dateLastService?: string | null
+      lastServiceCount?: number | null
+      firmwareVersion?: string | null
+      notes?: string | null
     },
   ): Promise<CustomerMachine>
   updateCustomerMachine(
@@ -87,6 +96,14 @@ type StorageApi = {
       toolSerialNumbers?: string[]
       siteId?: string | null
       projectId?: string | null
+      model?: string | null
+      make?: string | null
+      handing?: MachineHanding | null
+      dateInstalled?: string | null
+      dateLastService?: string | null
+      lastServiceCount?: number | null
+      firmwareVersion?: string | null
+      notes?: string | null
     },
   ): Promise<CustomerMachine>
   deleteCustomerMachine(customerId: string, machineId: string): Promise<void>
@@ -234,6 +251,14 @@ export function createCustomerMachine(
     toolSerialNumbers?: string[]
     siteId?: string | null
     projectId?: string | null
+    model?: string | null
+    make?: string | null
+    handing?: MachineHanding | null
+    dateInstalled?: string | null
+    dateLastService?: string | null
+    lastServiceCount?: number | null
+    firmwareVersion?: string | null
+    notes?: string | null
   },
 ): Promise<CustomerMachine> {
   return ensureLocalStorage().createCustomerMachine(customerId, data)
@@ -248,6 +273,14 @@ export function updateCustomerMachine(
     toolSerialNumbers?: string[]
     siteId?: string | null
     projectId?: string | null
+    model?: string | null
+    make?: string | null
+    handing?: MachineHanding | null
+    dateInstalled?: string | null
+    dateLastService?: string | null
+    lastServiceCount?: number | null
+    firmwareVersion?: string | null
+    notes?: string | null
   },
 ): Promise<CustomerMachine> {
   return ensureLocalStorage().updateCustomerMachine(customerId, machineId, data)
@@ -859,6 +892,24 @@ function createLocalStorageStorage(): StorageApi {
 
     const idRaw = typeof raw.id === 'string' ? raw.id.trim() : ''
     const lineReference = toOptionalString((raw as { lineReference?: unknown }).lineReference)
+    const model = toOptionalString((raw as { model?: unknown }).model)
+    const make = toOptionalString((raw as { make?: unknown }).make)
+    const handingRaw = toOptionalString((raw as { handing?: unknown }).handing)?.toLowerCase()
+    const handing = handingRaw === 'left' || handingRaw === 'right' ? (handingRaw as MachineHanding) : undefined
+    const dateInstalled = normalizeDateOnlyValue((raw as { dateInstalled?: unknown }).dateInstalled)
+    const dateLastService = normalizeDateOnlyValue((raw as { dateLastService?: unknown }).dateLastService)
+    const firmwareVersion = toOptionalString((raw as { firmwareVersion?: unknown }).firmwareVersion)
+    const notes = toOptionalString((raw as { notes?: unknown }).notes)
+    let lastServiceCount: number | undefined
+    const lastServiceCountRaw = (raw as { lastServiceCount?: unknown }).lastServiceCount
+    if (typeof lastServiceCountRaw === 'number' && Number.isFinite(lastServiceCountRaw)) {
+      lastServiceCount = Math.max(0, Math.floor(lastServiceCountRaw))
+    } else if (typeof lastServiceCountRaw === 'string') {
+      const parsed = parseInt(lastServiceCountRaw.trim(), 10)
+      if (!Number.isNaN(parsed)) {
+        lastServiceCount = Math.max(0, parsed)
+      }
+    }
     const toolSerialNumbersSource = Array.isArray(
       (raw as { toolSerialNumbers?: unknown }).toolSerialNumbers,
     )
@@ -893,6 +944,14 @@ function createLocalStorageStorage(): StorageApi {
       toolSerialNumbers,
       siteId: siteId ?? undefined,
       projectId: projectId ?? undefined,
+      model: model ?? undefined,
+      make: make ?? undefined,
+      handing,
+      dateInstalled: dateInstalled ?? undefined,
+      dateLastService: dateLastService ?? undefined,
+      lastServiceCount,
+      firmwareVersion: firmwareVersion ?? undefined,
+      notes: notes ?? undefined,
     }
   }
 
@@ -1252,6 +1311,10 @@ function createLocalStorageStorage(): StorageApi {
     const signedByPosition = toOptionalString((raw as { signedByPosition?: unknown }).signedByPosition)
     const signatureDataUrl = toOptionalString((raw as { signatureDataUrl?: unknown }).signatureDataUrl)
     const pdfDataUrl = toOptionalString((raw as { pdfDataUrl?: unknown }).pdfDataUrl)
+    const machineId = toOptionalString((raw as { machineId?: unknown }).machineId)
+    const machineSerialNumber = toOptionalString((raw as { machineSerialNumber?: unknown }).machineSerialNumber)
+    const serviceInformation = toOptionalString((raw as { serviceInformation?: unknown }).serviceInformation)
+    const firmwareVersion = toOptionalString((raw as { firmwareVersion?: unknown }).firmwareVersion)
     const createdAtRaw = typeof raw.createdAt === 'string' ? raw.createdAt : null
     const createdAt =
       createdAtRaw && !Number.isNaN(Date.parse(createdAtRaw))
@@ -1274,6 +1337,10 @@ function createLocalStorageStorage(): StorageApi {
       signatureDataUrl,
       pdfDataUrl,
       createdAt,
+      machineId: machineId ?? undefined,
+      machineSerialNumber: machineSerialNumber ?? undefined,
+      serviceInformation: serviceInformation ?? undefined,
+      firmwareVersion: firmwareVersion ?? undefined,
     }
   }
 
@@ -1856,6 +1923,14 @@ function createLocalStorageStorage(): StorageApi {
       toolSerialNumbers: [...machine.toolSerialNumbers],
       siteId: machine.siteId,
       projectId: machine.projectId,
+      model: machine.model,
+      make: machine.make,
+      handing: machine.handing,
+      dateInstalled: machine.dateInstalled,
+      dateLastService: machine.dateLastService,
+      lastServiceCount: machine.lastServiceCount,
+      firmwareVersion: machine.firmwareVersion,
+      notes: machine.notes,
     }
   }
 
@@ -2153,6 +2228,14 @@ function createLocalStorageStorage(): StorageApi {
         toolSerialNumbers?: string[]
         siteId?: string | null
         projectId?: string | null
+        model?: string | null
+        make?: string | null
+        handing?: MachineHanding | null
+        dateInstalled?: string | null
+        dateLastService?: string | null
+        lastServiceCount?: number | null
+        firmwareVersion?: string | null
+        notes?: string | null
       },
     ): Promise<CustomerMachine> {
       const db = loadDatabase()
@@ -2188,6 +2271,14 @@ function createLocalStorageStorage(): StorageApi {
         toolSerialNumbers: Array.isArray(data.toolSerialNumbers) ? data.toolSerialNumbers : [],
         siteId: normalizedSiteId,
         projectId: normalizedProjectId,
+        model: data.model ?? undefined,
+        make: data.make ?? undefined,
+        handing: data.handing ?? undefined,
+        dateInstalled: data.dateInstalled ?? undefined,
+        dateLastService: data.dateLastService ?? undefined,
+        lastServiceCount: data.lastServiceCount ?? undefined,
+        firmwareVersion: data.firmwareVersion ?? undefined,
+        notes: data.notes ?? undefined,
       })
 
       if (!machine) {
@@ -2216,6 +2307,14 @@ function createLocalStorageStorage(): StorageApi {
         toolSerialNumbers?: string[]
         siteId?: string | null
         projectId?: string | null
+        model?: string | null
+        make?: string | null
+        handing?: MachineHanding | null
+        dateInstalled?: string | null
+        dateLastService?: string | null
+        lastServiceCount?: number | null
+        firmwareVersion?: string | null
+        notes?: string | null
       },
     ): Promise<CustomerMachine> {
       const db = loadDatabase()
@@ -2262,6 +2361,18 @@ function createLocalStorageStorage(): StorageApi {
           data.toolSerialNumbers === undefined ? currentMachine.toolSerialNumbers : data.toolSerialNumbers ?? [],
         siteId: normalizedSiteId,
         projectId: normalizedProjectId,
+        model: data.model === undefined ? currentMachine.model : data.model ?? undefined,
+        make: data.make === undefined ? currentMachine.make : data.make ?? undefined,
+        handing: data.handing === undefined ? currentMachine.handing : data.handing ?? undefined,
+        dateInstalled:
+          data.dateInstalled === undefined ? currentMachine.dateInstalled : data.dateInstalled ?? undefined,
+        dateLastService:
+          data.dateLastService === undefined ? currentMachine.dateLastService : data.dateLastService ?? undefined,
+        lastServiceCount:
+          data.lastServiceCount === undefined ? currentMachine.lastServiceCount : data.lastServiceCount ?? undefined,
+        firmwareVersion:
+          data.firmwareVersion === undefined ? currentMachine.firmwareVersion : data.firmwareVersion ?? undefined,
+        notes: data.notes === undefined ? currentMachine.notes : data.notes ?? undefined,
       })
 
       if (!normalizedMachine) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,8 @@ export type ProjectMachine = {
   toolSerialNumbers: string[];
 };
 
+export type MachineHanding = 'left' | 'right';
+
 export type CustomerMachine = {
   id: string;
   machineSerialNumber: string;
@@ -65,6 +67,14 @@ export type CustomerMachine = {
   toolSerialNumbers: string[];
   siteId?: string;
   projectId?: string;
+  model?: string;
+  make?: string;
+  handing?: MachineHanding;
+  dateInstalled?: string;
+  dateLastService?: string;
+  lastServiceCount?: number;
+  firmwareVersion?: string;
+  notes?: string;
 };
 
 export type ProjectInfo = {
@@ -138,6 +148,10 @@ export type ProjectOnsiteReport = {
   signatureDataUrl?: string;
   pdfDataUrl?: string;
   createdAt: string;
+  machineId?: string;
+  machineSerialNumber?: string;
+  serviceInformation?: string;
+  firmwareVersion?: string;
 };
 
 export type CustomerSignOffDecision = 'option1' | 'option2' | 'option3';


### PR DESCRIPTION
## Summary
- extend customer machine data with metadata fields for model, make, handing, service dates, counts, firmware, and notes
- create a dedicated machine detail page that surfaces the new fields alongside linked onsite report history
- capture machine selection, service information, and firmware in onsite reports, updating machine records and generated PDFs

## Testing
- npm run build *(fails: `vite` binary lacks execute permission in repo)*
- npx tsc -b
- node node_modules/vite/bin/vite.js build


------
https://chatgpt.com/codex/tasks/task_e_68dfb258430c8321b2a1ab7222f3da87