### PR TITLE
Automatically select the only customer site tab

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1109,6 +1109,13 @@ function AppContent() {
       }
       return
     }
+    if (siteTabs.length === 1) {
+      const [onlyTab] = siteTabs
+      if (customerSiteTab !== onlyTab.key) {
+        setCustomerSiteTab(onlyTab.key)
+      }
+      return
+    }
     if (!siteTabs.some(tab => tab.key === customerSiteTab)) {
       setCustomerSiteTab(defaultSiteTabKey)
     }


### PR DESCRIPTION
## Summary
- ensure the customer site tab state snaps to the sole available tab so site details render automatically

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e37dd3675c832186dc774982e67c53