### PR TITLE
Fix BOM PDF generation fallback and add test

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6485,18 +6485,20 @@ function AppContent() {
     projectId: string,
     info: ProjectInfo | null,
   ) {
-    if (!info?.bomEntries || info.bomEntries.length === 0) {
-      return
-    }
-
     const customer = db.find(entry => entry.id === customerId)
     const project = customer?.projects.find(entry => entry.id === projectId)
     if (!customer || !project) {
       return
     }
 
-    const partsById = new Map((info.partsCatalog ?? []).map(part => [part.id, part]))
-    const rows = info.bomEntries
+    const bomInfo = info ?? project.info
+    if (!bomInfo?.bomEntries || bomInfo.bomEntries.length === 0) {
+      return
+    }
+
+    const partsCatalog = bomInfo.partsCatalog ?? project.info?.partsCatalog ?? []
+    const partsById = new Map(partsCatalog.map(part => [part.id, part]))
+    const rows = bomInfo.bomEntries
       .map(entry => {
         const part = partsById.get(entry.partId)
         const partNumber = part?.partNumber ?? entry.partId

--- a/tests/bom-pdf.test.ts
+++ b/tests/bom-pdf.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { generateBomPdf } from '../src/lib/signOff'
+
+test('generateBomPdf returns a valid PDF data URL', async () => {
+  const dataUrl = await generateBomPdf({
+    businessName: 'Test Company',
+    businessLogo: null,
+    projectNumber: 'P-1234',
+    customerName: 'Sample Customer',
+    createdAt: new Date('2024-01-01T00:00:00.000Z').toISOString(),
+    rows: [
+      { partNumber: 'PN-1', quantity: '2', description: 'Widget', designations: 'A1' },
+    ],
+  })
+
+  assert.ok(dataUrl.startsWith('data:application/pdf;base64,'))
+  const base64 = dataUrl.split(',', 2)[1]
+  const bytes = Buffer.from(base64, 'base64')
+  assert.ok(bytes.subarray(0, 8).toString('ascii').startsWith('%PDF-1.'))
+})


### PR DESCRIPTION
### Motivation
- Ensure BOM PDF generation runs when saving a project BOM even if the `info` argument is null by falling back to the saved project info and parts catalog.

### Description
- Update `refreshProjectBomDocument` in `src/app/App.tsx` to use `const bomInfo = info ?? project.info` and bail out only if `bomInfo.bomEntries` is empty, and to derive `partsCatalog` from `bomInfo` or `project.info` as a fallback so part lookups succeed.
- Add a regression test `tests/bom-pdf.test.ts` that calls `generateBomPdf` and validates the returned data URL and PDF header.
- No external skills were used for this change.

### Testing
- Ran the test suite with `npm test`, which executed the new test `tests/bom-pdf.test.ts` and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69835256aefc8321bd408b17c8102fdc)